### PR TITLE
1 feature request add apache iceberg and disaster recovery for iceberg support

### DIFF
--- a/deployment/cdk/cdk.context.json
+++ b/deployment/cdk/cdk.context.json
@@ -29,7 +29,7 @@
                     "s3:DeleteObject"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::<S3_BUCKET_NAME>/*",
+                    "arn:aws:s3:::<S3_BUCKET_NAME>/*"
                   ]
                 }
               ]

--- a/deployment/cdk/cdk.context.json
+++ b/deployment/cdk/cdk.context.json
@@ -18,7 +18,8 @@
                     "s3:ListBucket"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::<S3_BUCKET_NAME>"
+                    "arn:aws:s3:::<S3_BUCKET_NAME>",
+                    "arn:aws:s3::<ACCOUNT_ID>:accesspoint/<MRAP ALIAS>"
                   ]
                 },
                 {
@@ -29,7 +30,8 @@
                     "s3:DeleteObject"
                   ],
                   "Resource": [
-                    "arn:aws:s3:::<S3_BUCKET_NAME>/*"
+                    "arn:aws:s3:::<S3_BUCKET_NAME>/*",
+                    "arn:aws:s3::<ACCOUNT_ID>:accesspoint/<MRAP ALIAS>/*"
                   ]
                 }
               ]

--- a/deployment/cdk/lib/resources/managed-endpoint.json
+++ b/deployment/cdk/lib/resources/managed-endpoint.json
@@ -21,7 +21,23 @@
                 "spark.kubernetes.driver.node.selector.node-lifecycle": "on-demand",
                 "spark.kubernetes.executor.node.selector.node-lifecycle": "spot",
                 "spark.dynamicAllocation.enabled": "true",
-                "spark.dynamicAllocation.executorAllocationRatio": "1"
+                "spark.dynamicAllocation.executorAllocationRatio": "1",
+                "spark.sql.sources.partitionOverwriteMode": "dynamic",
+                "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+                "spark.sql.defaultCatalog":"glue_catalog",
+                "spark.sql.catalog.glue_catalog": "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.glue_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.glue_catalog.io-impl": "org.apache.iceberg.aws.s3.S3FileIO",
+                "spark.sql.catalog.glue_catalog.lock-impl": "org.apache.iceberg.aws.dynamodb.DynamoDbLockManager",
+                "spark.sql.catalog.glue_catalog.dynamodb.table-name":"glue_metastore",
+                "spark.sql.catalog.glue_catalog.lock.table": "GlueLockTable",
+                "spark.jars": "local:///usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar",
+                "spark.sql.catalog.glue_catalog.s3.use-arn-region-enabled":"true",
+                "spark.sql.catalog.glue_catalog.client.credentials-provider":"software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider",
+                "spark.executor.extraJavaOptions":"-Dcom.amazonaws.services.s3.enableV4=true",
+                "spark.driver.extraJavaOptions":"-Dcom.amazonaws.services.s3.enableV4=true",
+                "spark.sql.catalog.glue_catalog.s3.access-points.iceberg-warehouse-mrap":"<MRAP ARN>",
+                "spark.sql.catalog.glue_catalog.warehouse":"s3://<S3_BUCKET_NAME>/iceberg/"
             }
         },
         {

--- a/deployment/cdk/lib/resources/managed-endpoint.json
+++ b/deployment/cdk/lib/resources/managed-endpoint.json
@@ -36,8 +36,8 @@
                 "spark.sql.catalog.glue_catalog.client.credentials-provider":"software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider",
                 "spark.executor.extraJavaOptions":"-Dcom.amazonaws.services.s3.enableV4=true",
                 "spark.driver.extraJavaOptions":"-Dcom.amazonaws.services.s3.enableV4=true",
-                "spark.sql.catalog.glue_catalog.s3.access-points.iceberg-warehouse-mrap":"<MRAP ARN>",
-                "spark.sql.catalog.glue_catalog.warehouse":"s3://<S3_BUCKET_NAME>/iceberg/"
+                "spark.sql.catalog.glue_catalog.warehouse":"s3://<S3_BUCKET_NAME>/iceberg/",
+                "spark.sql.catalog.glue_catalog.s3.access-points.<s3-endpoint>":"arn:aws:s3::<ACCOUNT_ID>:accesspoint/<MRAP_ALIAS>"
             }
         },
         {

--- a/deployment/cdk/package.json
+++ b/deployment/cdk/package.json
@@ -20,11 +20,12 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-analytics-reference-architecture": "2.9.14",
-    "aws-cdk-lib": "2.72.1",
-    "@aws-cdk/lambda-layer-kubectl-v23":"^2.0.0",
-    "cdk-nag": "^2.22.5",
-    "constructs": "^10.1.308",
+    "aws-analytics-reference-architecture": "2.12.4",
+    "@aws-cdk/lambda-layer-kubectl-v25": "^2.0.3",
     "source-map-support": "^0.5.21"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "2.72.1",
+    "constructs": "^10.1.308"
   }
 }

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,7 @@
 ARG ECR_ACCOUNT="755674844232"
 ARG ECR_REGION="us-east-1"
 ARG CONTAINER_TYPE="notebook-spark"
-ARG CONTAINER_IMAGE="emr-6.8.0:latest"
+ARG CONTAINER_IMAGE="emr-6.10.0:latest"
 
 FROM ${ECR_ACCOUNT}.dkr.ecr.${ECR_REGION}.amazonaws.com/${CONTAINER_TYPE}/${CONTAINER_IMAGE}
 USER root
@@ -16,4 +16,13 @@ RUN rm /usr/bin/python3
 RUN ln -s /usr/local/bin/python3.9 /usr/bin/python3
 ENV MPLLOCALFREETYPE 1
 RUN pip3.9 install --upgrade matplotlib==3.2.2 kaleido backtrader pandas sklearn numpy pyarrow s3fs bokeh vectorbt pyEX alpaca-py pyfolio awswrangler boto3 yfinance
+
+RUN rm /usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar
+RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.20.18/bundle-2.20.18.jar -Lo /usr/share/aws/aws-java-sdk/bundle-2.20.18.jar
+RUN curl https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.3.0/iceberg-spark-runtime-3.3_2.12-1.3.0.jar -Lo /usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar
+
+RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/auth/2.20.18/auth-2.20.18.jar -Lo /usr/share/aws/aws-java-sdk/auth-2.20.18.jar
+RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/auth-crt/2.20.18/auth-crt-2.20.18.jar -Lo /usr/share/aws/aws-java-sdk/auth-crt-2.20.18.jar
+RUN curl https://repo1.maven.org/maven2/software/amazon/awssdk/crt/aws-crt/0.21.14/aws-crt-0.21.14.jar -Lo /usr/share/aws/aws-java-sdk/aws-crt-0.21.14.jar
+
 USER hadoop:hadoop

--- a/src/notebooks/etf holdings/notebook.ipynb
+++ b/src/notebooks/etf holdings/notebook.ipynb
@@ -1,0 +1,1318 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "38162372-a37c-4693-bf8e-f6aa979e84e7",
+   "metadata": {},
+   "source": [
+    "## Experiment\n",
+    "As SPY ETF holdings changes over time. So we build a simple strategy around that. Portfolio goes long stocks added to the index and shorts equivalent amount of stocks deleted. To keep this notebook simple we only traded following stocks `PENN`, `PVH`, `INVH`, `CSGP`.\n",
+    "We test short-term holding period such as entry_point `2022-09-02`, exit_point `2022-10-31`. However this experiment can be extended as backtesting libraries like `vectorbt`, `backtrader`,`alpaca-py`, `pyfolio` are all baked into this docker image so that customers don't have to spend time figuring out dependency management.\n",
+    "\n",
+    "ETF holding changes are as follows:\n",
+    "**announcement date:**  2022-09-02\n",
+    "**effective date:** 2022-09-19"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "73b3d5c0-4a2f-4223-b54f-146a7129c5f3",
+   "metadata": {},
+   "source": [
+    "### Data Preparation\n",
+    "\n",
+    "In this section we are going to prepare dataset using data provider's API. First we'll download the SPY ETF holdings for Q1 2022. We'll tag this data as 2022Q1 to be able to access state of the table later on easily. The next update from data provider api is on Q3 2022 therefore first we'll expire the stocks in the etf holdings table and merge new stocks into it. If stocks are matching then we'll set the status as `unchanged` to state that stock is still part of etf. If there are additional stocks in the new dataset then we'll set the status as `new`. If new dataset is lacking some stocks that existing etf_holdings table has then we'll leave these stocks status as `expired` to state that these stocks are no longer in the etf. Each state transition will be tagged for trackability purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b585ee3-8906-491a-8579-2ed7d8695318",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "from pyspark.sql import functions as f\n",
+    "\n",
+    "API_KEY='{YOUR API KEY}'\n",
+    "\n",
+    "def url_for_etf_holdings(date):\n",
+    "    return f'https://url/to/dataendpoint'\n",
+    "\n",
+    "\n",
+    "def load_json_as_dataframe(url, selector=None):    \n",
+    "    data = requests.get(url).content.decode('utf-8')\n",
+    "    json_data = json.loads(data)\n",
+    "    rdd = spark.sparkContext.parallelize(json_data[selector] if selector else json_data)\n",
+    "    return spark.read.json(rdd)\n",
+    "\n",
+    "(\n",
+    "    load_json_as_dataframe(url_for_etf_holdings('2022-03-31'))\n",
+    "    .withColumn(\"status\",f.lit(\"new\"))\n",
+    "    .createOrReplaceTempView(\"2022Q1\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c85a08de-8149-4a4b-8b52-c7d053a3c6ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(\"DROP TABLE IF EXISTS glue_catalog.quant.etf_holdings\")\n",
+    "spark.sql(\"\"\"\n",
+    "CREATE TABLE glue_catalog.quant.etf_holdings\n",
+    "USING iceberg\n",
+    "OPTIONS ('format-version'='2')\n",
+    "LOCATION 's3://trader-warehouse-us-east-1/etf_holdings/'\n",
+    "AS SELECT * FROM 2022Q1\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0ee78111-b4ee-4dca-895d-50d98b48600f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:26:49.479857Z",
+     "iopub.status.busy": "2023-04-05T13:26:49.479453Z",
+     "iopub.status.idle": "2023-04-05T13:26:50.918903Z",
+     "shell.execute_reply": "2023-04-05T13:26:50.918157Z",
+     "shell.execute_reply.started": "2023-04-05T13:26:49.479829Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+-------------------+------+\n",
+      "|symbol|      date|     acceptanceTime|status|\n",
+      "+------+----------+-------------------+------+\n",
+      "|   HON|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   DFS|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   FMC|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  NDSN|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   CRL|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  EPAM|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  CSCO|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   ALB|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   AIZ|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   CRM|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  PENN|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  INTU|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   DOW|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   LHX|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   BLK|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  ZBRA|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   UPS|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|    DG|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  DISH|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|      |2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "+------+----------+-------------------+------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Quick look at the table if we have the data\n",
+    "spark.table(\"glue_catalog.quant.etf_holdings\").select(\"symbol\",\"date\",\"acceptanceTime\", \"status\").show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2195932c-c9d6-4386-ab5e-2eab7f6da2a2",
+   "metadata": {},
+   "source": [
+    "#### Labeling Table\n",
+    "\n",
+    "Here we are going to label this initial table so that later on we can access the state of the table as it was later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "de59f837-d906-4554-bdaf-0f1f0e354f7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:26:55.696055Z",
+     "iopub.status.busy": "2023-04-05T13:26:55.695633Z",
+     "iopub.status.idle": "2023-04-05T13:26:56.596457Z",
+     "shell.execute_reply": "2023-04-05T13:26:56.595844Z",
+     "shell.execute_reply.started": "2023-04-05T13:26:55.696026Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(\"ALTER TABLE glue_catalog.quant.etf_holdings CREATE TAG Q1_2022\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "92b2d2cd-1718-4f26-99cb-dbd04ae867aa",
+   "metadata": {},
+   "source": [
+    "### Simulate a Scenario of ETF Holdings Table Ingestion\n",
+    "In this step we'll expire etf holdings first then merge new ones into it. If we already have the stock in the existing table then we'll set status back to unchanged. If there are new stocks they'll be registered as new. Non matching stocks will stay expired. That way in this table we'll be able keep both new, unchanged and expired stocks in the etf holdings table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5fc2f97f-32e3-4e95-8177-7a9a46b50d22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:26:58.647980Z",
+     "iopub.status.busy": "2023-04-05T13:26:58.647590Z",
+     "iopub.status.idle": "2023-04-05T13:27:14.343615Z",
+     "shell.execute_reply": "2023-04-05T13:27:14.342867Z",
+     "shell.execute_reply.started": "2023-04-05T13:26:58.647951Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(\"\"\"\n",
+    "UPDATE glue_catalog.quant.etf_holdings\n",
+    "SET status = 'expired'\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1048dc4b-f441-4deb-8387-3d3b7bd72caa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:14.345233Z",
+     "iopub.status.busy": "2023-04-05T13:27:14.344873Z",
+     "iopub.status.idle": "2023-04-05T13:27:14.594218Z",
+     "shell.execute_reply": "2023-04-05T13:27:14.593293Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:14.345209Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+-------------------+-------+\n",
+      "|symbol|      date|     acceptanceTime| status|\n",
+      "+------+----------+-------------------+-------+\n",
+      "|   HON|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   DFS|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   FMC|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  NDSN|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   CRL|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  EPAM|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  CSCO|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   ALB|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   AIZ|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   CRM|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  PENN|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  INTU|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   DOW|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   LHX|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   BLK|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  ZBRA|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|   UPS|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|    DG|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|  DISH|2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "|      |2022-03-31|2022-05-27 13:54:03|expired|\n",
+      "+------+----------+-------------------+-------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.table(\"glue_catalog.quant.etf_holdings\").select(\"symbol\",\"date\",\"acceptanceTime\", \"status\").show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "17ed7ac2-5240-4064-86a7-2abc776fc685",
+   "metadata": {},
+   "source": [
+    "Now entire table is in expired state. However we can still query the table in the previous state using tags. So that quants won't be effected from ongoing maintanence task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9c46be23-8326-4fb9-87a6-79acf8c6b702",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:14.596008Z",
+     "iopub.status.busy": "2023-04-05T13:27:14.595563Z",
+     "iopub.status.idle": "2023-04-05T13:27:14.840098Z",
+     "shell.execute_reply": "2023-04-05T13:27:14.839414Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:14.595966Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+-------------------+------+\n",
+      "|symbol|      date|     acceptanceTime|status|\n",
+      "+------+----------+-------------------+------+\n",
+      "|   HON|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   DFS|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   FMC|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  NDSN|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   CRL|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  EPAM|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  CSCO|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   ALB|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   AIZ|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   CRM|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  PENN|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  INTU|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   DOW|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   LHX|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   BLK|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  ZBRA|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|   UPS|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|    DG|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|  DISH|2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "|      |2022-03-31|2022-05-27 13:54:03|   new|\n",
+      "+------+----------+-------------------+------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(\"\"\"SELECT symbol, date, acceptanceTime, status \n",
+    "FROM glue_catalog.quant.etf_holdings \n",
+    "VERSION AS OF 'Q1_2022'\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "f1f31dcb-d3da-490c-b2da-2d600fc46d5c",
+   "metadata": {},
+   "source": [
+    "So while quants are busy with working on this branch of the data ongoing ETL process is now going to update the data with new ETF holdings data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "da1a85dd-6562-445a-b150-d98c688fa653",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:14.842034Z",
+     "iopub.status.busy": "2023-04-05T13:27:14.841714Z",
+     "iopub.status.idle": "2023-04-05T13:27:18.901064Z",
+     "shell.execute_reply": "2023-04-05T13:27:18.900364Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:14.842010Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(\n",
+    "    load_json_as_dataframe(url_for_etf_holdings('2022-09-30'))\n",
+    "    .withColumn(\"status\",f.lit(\"new\"))\n",
+    "    .createOrReplaceTempView(\"2022Q3\")\n",
+    ")\n",
+    "\n",
+    "spark.sql(\"\"\"\n",
+    "MERGE INTO glue_catalog.quant.etf_holdings t\n",
+    "USING (SELECT * FROM 2022Q3) s\n",
+    "ON t.isin = s.isin\n",
+    "WHEN MATCHED THEN\n",
+    "    UPDATE SET t.acceptanceTime = s.acceptanceTime,\n",
+    "               t.date = s.date,\n",
+    "               t.balance = s.balance,\n",
+    "               t.valUsd = s.valUsd,\n",
+    "               t.pctVal = s.pctVal,\n",
+    "               t.status = \"unchanged\"\n",
+    "WHEN NOT MATCHED THEN INSERT *\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8135d3f5-59d6-4976-b4ef-99cb2cb97971",
+   "metadata": {},
+   "source": [
+    "Since now we merged new data into our existing table it's time to tag this as well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "79555d8f-05b9-4cca-b8f0-654316b8ad99",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:18.902363Z",
+     "iopub.status.busy": "2023-04-05T13:27:18.902079Z",
+     "iopub.status.idle": "2023-04-05T13:27:19.822659Z",
+     "shell.execute_reply": "2023-04-05T13:27:19.821962Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:18.902339Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(\"ALTER TABLE glue_catalog.quant.etf_holdings CREATE TAG Q3_2022\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ecba91d6-f935-4186-8c57-ee4aaa7da4e1",
+   "metadata": {},
+   "source": [
+    "Let's query the expired and newly added stocks to see the effect of rebalance on the ETF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "334c5655-68b0-4648-b489-a05e56ccfea0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:19.824082Z",
+     "iopub.status.busy": "2023-04-05T13:27:19.823564Z",
+     "iopub.status.idle": "2023-04-05T13:27:20.407301Z",
+     "shell.execute_reply": "2023-04-05T13:27:20.406403Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:19.824059Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+------------+-------------------+----------+\n",
+      "|symbol|        isin|     acceptanceTime|      date|\n",
+      "+------+------------+-------------------+----------+\n",
+      "|   CPT|US1331311027|2022-11-28 15:50:55|2022-09-30|\n",
+      "|  CSGP|US22160N1090|2022-11-28 15:50:55|2022-09-30|\n",
+      "|  EMBC|US29082K1051|2022-11-28 15:50:55|2022-09-30|\n",
+      "|  INVH|US46187W1071|2022-11-28 15:50:55|2022-09-30|\n",
+      "|     J|US46982L1089|2022-11-28 15:50:55|2022-09-30|\n",
+      "|   KDP|US49271V1008|2022-11-28 15:50:55|2022-09-30|\n",
+      "|    ON|US6821891057|2022-11-28 15:50:55|2022-09-30|\n",
+      "|  VICI|US9256521090|2022-11-28 15:50:55|2022-09-30|\n",
+      "|   WBD|US9344231041|2022-11-28 15:50:55|2022-09-30|\n",
+      "+------+------------+-------------------+----------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(\"\"\"SELECT symbol, isin, acceptanceTime, date \n",
+    "FROM glue_catalog.quant.etf_holdings \n",
+    "where status='new'\n",
+    "\"\"\").show()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ad4684bc-1896-41c7-9a7b-392a082c975c",
+   "metadata": {},
+   "source": [
+    "Also let's query expired stocks to see which ones are removed from the ETF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "dfae7fed-ec55-4a50-9cc9-89bf5d5625f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:27:20.408567Z",
+     "iopub.status.busy": "2023-04-05T13:27:20.408261Z",
+     "iopub.status.idle": "2023-04-05T13:27:20.624090Z",
+     "shell.execute_reply": "2023-04-05T13:27:20.623401Z",
+     "shell.execute_reply.started": "2023-04-05T13:27:20.408533Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+------------+-------------------+----------+\n",
+      "|symbol|        isin|     acceptanceTime|      date|\n",
+      "+------+------------+-------------------+----------+\n",
+      "|  PENN|US7075691094|2022-05-27 13:54:03|2022-03-31|\n",
+      "|    UA|US9043112062|2022-05-27 13:54:03|2022-03-31|\n",
+      "|   UAA|US9043111072|2022-05-27 13:54:03|2022-03-31|\n",
+      "|   LTP|US7127041058|2022-05-27 13:54:03|2022-03-31|\n",
+      "| DISCA|US25470F1049|2022-05-27 13:54:03|2022-03-31|\n",
+      "|  CERN|US1567821046|2022-05-27 13:54:03|2022-03-31|\n",
+      "|  IPGP|US44980X1090|2022-05-27 13:54:03|2022-03-31|\n",
+      "|      |US25470F3029|2022-05-27 13:54:03|2022-03-31|\n",
+      "|     J|US4698141078|2022-05-27 13:54:03|2022-03-31|\n",
+      "|   PVH|US6936561009|2022-05-27 13:54:03|2022-03-31|\n",
+      "+------+------------+-------------------+----------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.sql(\"\"\"SELECT symbol, isin, acceptanceTime, date \n",
+    "FROM glue_catalog.quant.etf_holdings \n",
+    "where status='expired'\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "abd4f3eb-07d5-477a-934e-de2ccaa60741",
+   "metadata": {},
+   "source": [
+    "### Backtesting\n",
+    "In this section we'll backtest the strategy that about is taking long position for stocks that are added to ETF such as `CSGP` and `INVH` and taking short position that are removed from the index such as `PVH` and `PENN`. First we'll examine this strategy on the chart to see if divergence really happened. To do that we need historical data for CSGP, INVH, PVH and PENN as well as SPY to see how ETF behaved overtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "04378904-6659-4341-8bf7-2436bfe5ccc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:29:08.431884Z",
+     "iopub.status.busy": "2023-04-05T13:29:08.431490Z",
+     "iopub.status.idle": "2023-04-05T13:29:20.243538Z",
+     "shell.execute_reply": "2023-04-05T13:29:20.242795Z",
+     "shell.execute_reply.started": "2023-04-05T13:29:08.431858Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "symbols = [\"CSGP\", \"INVH\", \"PVH\", \"PENN\"]\n",
+    "\n",
+    "def url_for_historical_data(symbol, date_from, date_to):\n",
+    "    return f'https://financialmodelingprep.com/api/v3/historical-price-full/{symbol}?from={date_from}&to={date_to}&apikey={API_KEY}'\n",
+    "\n",
+    "\n",
+    "def historical_data_for(symbol, columns=[\"open\", \"high\", \"low\", \"close\", \"adjClose\"]):\n",
+    "    cols = [f.col(c).alias(f\"{symbol}_{c}\") for c in columns]\n",
+    "    cols.insert(0, \"date\") \n",
+    "    return (\n",
+    "        load_json_as_dataframe(\n",
+    "            url_for_historical_data(symbol, \"2022-08-01\", \"2022-12-01\"), \n",
+    "            \"historical\"\n",
+    "        )\n",
+    "        .select(cols)\n",
+    "    )\n",
+    "\n",
+    "spark.sql(\"DROP TABLE IF EXISTS glue_catalog.quant.historical_prices\")\n",
+    "\n",
+    "(\n",
+    "    historical_data_for(\"SPY\",[\"open\",\"close\"])\n",
+    "        .orderBy(\"date\")\n",
+    "        .writeTo(\"glue_catalog.quant.historical_prices\")\n",
+    "        .using(\"iceberg\")\n",
+    "        .createOrReplace()\n",
+    ")\n",
+    "\n",
+    "for symbol in symbols:\n",
+    "    (\n",
+    "        historical_data_for(symbol,[\"open\",\"close\"]).join(\n",
+    "            spark.table(\"glue_catalog.quant.historical_prices\"), \n",
+    "            on = \"date\", \n",
+    "            how = \"left\")\n",
+    "        .orderBy(\"date\")\n",
+    "        .writeTo(\"quant.historical_prices\")\n",
+    "        .using(\"iceberg\")\n",
+    "        .createOrReplace()\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "6ae24dc9-288f-456f-b64f-50322f681905",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:52:56.484409Z",
+     "iopub.status.busy": "2023-04-05T13:52:56.484002Z",
+     "iopub.status.idle": "2023-04-05T13:52:56.926359Z",
+     "shell.execute_reply": "2023-04-05T13:52:56.925678Z",
+     "shell.execute_reply.started": "2023-04-05T13:52:56.484381Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+---------+----------+--------+---------+---------+----------+---------+----------+--------+---------+\n",
+      "|      date|PENN_open|PENN_close|PVH_open|PVH_close|INVH_open|INVH_close|CSGP_open|CSGP_close|SPY_open|SPY_close|\n",
+      "+----------+---------+----------+--------+---------+---------+----------+---------+----------+--------+---------+\n",
+      "|2022-08-01|    33.94|     34.53|   61.61|    62.23|    38.96|     38.51|    71.92|     71.16|  409.15|   410.77|\n",
+      "|2022-08-02|    34.09|     36.17|   61.32|     61.2|    38.48|     37.98|    70.59|     70.99|  409.12|   408.06|\n",
+      "|2022-08-03|    36.91|     36.59|   62.14|    63.03|    38.11|     37.67|    71.31|     72.52|   410.3|   414.45|\n",
+      "|2022-08-04|     36.0|     35.14|   62.92|    63.73|    37.67|     37.92|    72.69|     72.87|  414.37|   414.17|\n",
+      "|2022-08-05|     34.2|     34.15|   63.19|    64.38|    37.68|     37.88|    71.66|     72.87|  409.66|   413.47|\n",
+      "|2022-08-08|    34.76|     36.05|   65.51|    66.36|    37.98|     37.92|    72.95|     72.87|  415.25|   412.99|\n",
+      "|2022-08-09|    35.52|     34.11|    65.9|    63.45|    37.96|     38.45|    72.38|     72.89|  412.22|   411.35|\n",
+      "|2022-08-10|    35.25|     35.74|   65.71|    65.64|    38.95|     38.94|    74.41|     74.73|  418.78|   419.99|\n",
+      "|2022-08-11|    36.48|      35.6|   66.95|    68.77|    39.06|     38.89|     74.7|     73.86|  422.99|   419.99|\n",
+      "|2022-08-12|    36.28|      37.7|   69.42|    68.97|     39.1|     39.59|    74.04|     75.06|  422.03|    427.1|\n",
+      "|2022-08-15|    37.23|     37.45|   67.99|    68.49|    39.74|     39.78|    74.55|     75.39| 424.765|   428.86|\n",
+      "|2022-08-16|    37.03|     37.21|   68.11|    70.98|    39.63|     39.81|     74.7|     75.13|  427.73|    429.7|\n",
+      "|2022-08-17|    36.21|     36.03|   69.38|    70.39|    39.48|     39.73|    74.38|      73.5|  425.91|   426.65|\n",
+      "|2022-08-18|    35.98|     35.72|   70.24|     70.2|    39.76|      38.8|    73.67|      73.5|  426.86|   427.89|\n",
+      "|2022-08-19|    35.01|     34.34|   69.63|     67.5|    38.84|     38.78|    72.57|     71.74|  424.98|   422.14|\n",
+      "|2022-08-22|    33.49|     32.86|    65.6|    64.01|     38.5|     38.26|    71.04|     71.57|  417.05|   413.35|\n",
+      "|2022-08-23|    32.86|     33.11|   64.69|    65.44|    38.09|     37.49|    71.07|     71.44|   412.9|   412.35|\n",
+      "|2022-08-24|    33.07|     33.65|   65.21|    66.08|    37.28|     37.68|     71.4|     71.05|  412.11|   413.67|\n",
+      "|2022-08-25|    34.06|      34.2|   66.24|    67.72|    37.87|     38.23|    71.62|      72.5|  415.24|   419.51|\n",
+      "|2022-08-26|   34.415|     32.18|   68.01|    64.03|    38.23|     37.28|    72.11|     70.32|  419.39|   405.31|\n",
+      "+----------+---------+----------+--------+---------+---------+----------+---------+----------+--------+---------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_68/2722982548.py:6: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df_prices.rename(columns={c:c.replace(f\"_{ohlcv}\",\"\") for c in columns}, inplace=True)\n",
+      "/tmp/ipykernel_68/2722982548.py:6: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df_prices.rename(columns={c:c.replace(f\"_{ohlcv}\",\"\") for c in columns}, inplace=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "historical_prices = spark.table(\"glue_catalog.quant.historical_prices\")\n",
+    "\n",
+    "def select_columns(df, ohlcv):\n",
+    "    columns = [cols for cols in df.columns if ohlcv in cols]\n",
+    "    df_prices = df[columns]\n",
+    "    df_prices.rename(columns={c:c.replace(f\"_{ohlcv}\",\"\") for c in columns}, inplace=True)\n",
+    "    return df_prices\n",
+    "\n",
+    "\n",
+    "historical_prices_pd = historical_prices.drop(\"SPY_open\",\"SPY_close\").toPandas()\n",
+    "historical_prices_pd['date'] = pd.to_datetime(historical_prices_pd['date'])\n",
+    "historical_prices_pd.set_index(\"date\", inplace=True)\n",
+    "\n",
+    "historical_open_prices = select_columns(historical_prices_pd, \"open\")\n",
+    "historical_close_prices = select_columns(historical_prices_pd, \"close\")\n",
+    "\n",
+    "historical_prices.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "95ed4201-d19b-45f3-86b6-b9ccf7399a17",
+   "metadata": {},
+   "source": [
+    "We have daily open and close prices for the assets we mentioned about. In the following section we'll calculate daily returns of each one of these stocks based on their daily close price difference. And show cumulative return on one chart to see how they diverge/converge from each other"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "75db44a3-b8f7-45b6-9390-79d6f7eccdb4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T13:35:58.626069Z",
+     "iopub.status.busy": "2023-04-05T13:35:58.625636Z",
+     "iopub.status.idle": "2023-04-05T13:35:59.533306Z",
+     "shell.execute_reply": "2023-04-05T13:35:59.532612Z",
+     "shell.execute_reply.started": "2023-04-05T13:35:58.626040Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:30: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "<>:30: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "/tmp/ipykernel_68/4001668177.py:30: SyntaxWarning: \"is\" with a literal. Did you mean \"==\"?\n",
+      "  color = \"green\" if col in stocks_added else \"blue\" if col is \"SPY\" else \"red\"\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/QAAAK9CAYAAACKBSdyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdeVwU9f8H8NewwMLucgqIeAACgniWtwEeUZ55I56IV5mp3zzK1F9KfvPMzL5+PTJTzMK8z/IutUxNy8wDFAnMAxUVQUBYYOf3x353ZeVadWFgeT0fj3kwzHxm5j0zO+J7P5/5fARRFEUQERERERERUaViIXUARERERERERPTsmNATERERERERVUJM6ImIiIiIiIgqISb0RERERERERJUQE3oiIiIiIiKiSogJPREREREREVElxISeiIiIiIiIqBJiQk9ERERERERUCTGhJyIiIiIiIqqEmNATEREVEBkZCS8vL5PuMzo6GoIgICkpyaT7JXpe7du3R/v27aUOg4iIXhATeiIiMrmEhAS89dZbqFu3LmxsbGBvb49XXnkFn3/+OR4/fix1eGVm7ty52LFjh9Rh6Om+SNBNlpaWqFmzJiIjI3Hz5s3n2uelS5cQFRVV6b+cSE9Px0cffYQmTZpApVLB1tYWDRs2xNSpU3Hr1i2pwyMiIjKKIIqiKHUQRERkPr7//nuEhYVBLpcjIiICDRs2hFqtxi+//IKtW7ciMjISq1atkjrMYkVGRuLIkSPPlbCqVCr069cP0dHRBsvz8/ORm5sLuVwOQRBME6gRoqOjMXz4cMyePRve3t7Izs7GyZMnER0dDS8vL1y4cAE2NjbPtM8tW7YgLCwMP/30U6Wt4f37778RGhqKf/75B2FhYQgKCoK1tTX++usvbNiwAc7Ozrhy5YrUYZYptVoNALC2tpY4EiIiehGWUgdARETmIzExEQMGDICnpyd+/PFH1KhRQ7/unXfewdWrV/H9999LGKE0ZDIZZDKZZMfv0qULmjdvDgAYNWoUXFxcsGDBAuzatQv9+/eXLK6CMjMzoVQqy/w4eXl56NOnD+7cuYMjR44gKCjIYP2cOXOwYMGCMo9DKllZWVAoFEzkiYjMBJvcExGRySxcuBAZGRn46quvDJJ5HV9fX/zrX/8CACQlJUEQhEK12QAgCAKioqL0v0dFRUEQBFy5cgVDhgyBg4MDXF1d8eGHH0IURVy/fh09e/aEvb093N3d8emnnxrsr7h32I8cOQJBEHDkyJESz2vRokVo27YtqlWrBltbWzRr1gxbtmwpFHNmZibWrVunb+IeGRlZ5PG7d++OunXrFnmsNm3a6JNvnW+++QbNmjWDra0tnJ2dMWDAAFy/fr3EmEsSHBwMQPtqREFxcXHo168fnJ2dYWNjg+bNm2PXrl369dHR0QgLCwMAdOjQQX+euuv39H3T8fLy0l8L3X4EQcDRo0cxduxYuLm5oVatWgC073Y3bNgQly5dQocOHaBQKFCzZk0sXLiw0H6XLl2KBg0aQKFQwMnJCc2bN0dMTEyJ575161acO3cOM2bMKJTMA4C9vT3mzJljsGzz5s366+/i4oIhQ4YUemUhMjISKpUK//zzD7p37w6VSoWaNWti2bJlAIDz58+jY8eOUCqV8PT0LBSn7pocO3YMb731FqpVqwZ7e3tEREQgNTXVoOzOnTvRrVs3eHh4QC6Xw8fHB//+97+Rn59vUE53LX///XeEhIRAoVBg+vTp+nVPt7Aw5nqePXsWXbp0gb29PVQqFV599VWcPHmyyHM5fvw4Jk2aBFdXVyiVSvTu3RspKSlF3RYiInpOTOiJiMhkdu/ejbp166Jt27Zlsv/w8HBoNBrMnz8frVq1wscff4wlS5bgtddeQ82aNbFgwQL4+vpiypQpOHbsmMmO+/nnn+Oll17C7NmzMXfuXFhaWiIsLMygtcH69eshl8sRHByM9evXY/369XjrrbeKPY/ExEScPn3aYPm1a9dw8uRJDBgwQL9szpw5iIiIgJ+fHxYvXox3330Xhw8fRkhICB4+fPhc56P7YsHJyUm/7OLFi2jdujViY2PxwQcf4NNPP4VSqUSvXr2wfft2AEBISAgmTJgAAJg+fbr+POvXr/9ccYwdOxaXLl3CzJkz8cEHH+iXp6amonPnzmjSpAk+/fRTBAQEYOrUqdi7d6++zJdffokJEyYgMDAQS5YswUcffYSmTZvi1KlTJR5T9wXF0KFDjYoxOjoa/fv3h0wmw7x58zB69Ghs27YNQUFBha5/fn4+unTpgtq1a2PhwoXw8vLCuHHjEB0djc6dO6N58+ZYsGAB7OzsEBERgcTExELHGzduHGJjYxEVFYWIiAh8++236NWrFwq+IRkdHQ2VSoVJkybh888/R7NmzQpdQ5379++jS5cuaNq0KZYsWYIOHToUeZ7GXM+LFy8iODgY586dw/vvv48PP/wQiYmJaN++fZHXffz48Th37hxmzZqFt99+G7t378a4ceOMuu5ERGQkkYiIyATS0tJEAGLPnj2NKp+YmCgCENeuXVtoHQBx1qxZ+t9nzZolAhDffPNN/bK8vDyxVq1aoiAI4vz58/XLU1NTRVtbW3HYsGH6ZWvXrhUBiImJiQbH+emnn0QA4k8//aRfNmzYMNHT09OgXFZWlsHvarVabNiwodixY0eD5Uql0uC4xR0/LS1NlMvl4uTJkw3KLVy4UBQEQbx27ZooiqKYlJQkymQycc6cOQblzp8/L1paWhZaXtxxDx06JKakpIjXr18Xt2zZIrq6uopyuVy8fv26vuyrr74qNmrUSMzOztYv02g0Ytu2bUU/Pz/9ss2bNxe6ZjpP3zcdT0/PIu9HUFCQmJeXZ1C2Xbt2IgDx66+/1i/LyckR3d3dxb59++qX9ezZU2zQoEGJ51+Ul156SXRwcDCqrFqtFt3c3MSGDRuKjx8/1i/fs2ePCECcOXOmftmwYcNEAOLcuXP1y3SfRUEQxO+++06/PC4urtC10l2TZs2aiWq1Wr984cKFIgBx586d+mVPfx5FURTfeustUaFQGNw/3bVcuXJlofLt2rUT27Vrp//dmOvZq1cv0draWkxISNAvu3XrlmhnZyeGhIQUOpfQ0FBRo9Hol0+cOFGUyWTiw4cPSzwOEREZjzX0RERkEunp6QAAOzu7MjvGqFGj9PMymQzNmzeHKIoYOXKkfrmjoyP8/f3x999/m+y4tra2+vnU1FSkpaUhODgYf/zxx3Ptz97eHl26dMGmTZsMal43btyI1q1bo06dOgCAbdu2QaPRoH///rh3755+cnd3h5+fH3766SejjhcaGgpXV1fUrl0b/fr1g1KpxK5du/TN3B88eIAff/wR/fv3x6NHj/THuX//Pjp16oT4+Pjn7hW/JKNHjy6ybwGVSoUhQ4bof7e2tkbLli0N7qmjoyNu3LhRqJVDadLT043+jJ45cwZ3797F2LFjDToP7NatGwICAorsD6LgZ1T3WVQqlQZ9Ffj7+8PR0bHIz+ibb74JKysr/e9vv/02LC0t8cMPP+iXFfw86u5XcHAwsrKyEBcXZ7A/uVyO4cOHl3qupV3P/Px8HDhwAL169TJ4XaRGjRoYNGgQfvnlF/2/AQXPpWAnkMHBwcjPz8e1a9dKjYeIiIzDhJ6IiEzC3t4egDbBKCu6RFfHwcEBNjY2cHFxKbT86feOX8SePXvQunVr2NjYwNnZGa6urlixYgXS0tKee5/h4eG4fv06Tpw4AUD7Pvvvv/+O8PBwfZn4+HiIogg/Pz+4uroaTLGxsbh7965Rx1q2bBkOHjyILVu2oGvXrrh37x7kcrl+/dWrVyGKIj788MNCx5k1axYAGH2sZ+Ht7V3k8lq1ahUaDcDJycngnk6dOhUqlQotW7aEn58f3nnnHRw/frzUY9rb2xv9GdUlnv7+/oXWBQQEFEpMbWxs4OrqarDMwcGhyPMp7jPq5+dn8LtKpUKNGjUM+n+4ePEievfuDQcHB9jb28PV1VX/BcjTn8maNWsa1QFeadczJSUFWVlZRV6L+vXrQ6PRFOrX4ennVfeKhymfTSKiqo693BMRkUnY29vDw8MDFy5cMKp8ccO3Pd2xV0FF1eYW13t8wZrv5zmWzs8//4wePXogJCQEy5cvR40aNWBlZYW1a9eW2gFbSd544w0oFAps2rQJbdu2xaZNm2BhYaHvdA4ANBoNBEHA3r17i63JNkbLli31He316tULQUFBGDRoEC5fvgyVSgWNRgMAmDJlCjp16lTkPnx9fZ/1FPWKu84Fa5oLMuae1q9fH5cvX8aePXuwb98+bN26FcuXL8fMmTPx0UcfFRtLQEAAzp49i+vXr6N27drPcBalKy5uY87HWA8fPkS7du1gb2+P2bNnw8fHBzY2Nvjjjz8wdepU/b3UKe4aP+15r2dJTHneRERUNCb0RERkMt27d8eqVatw4sQJtGnTpsSyutq6pzsWK4vmuC9yrK1bt8LGxgb79+83qNVeu3ZtobLPMsa8UqlE9+7dsXnzZixevBgbN25EcHAwPDw89GV8fHwgiiK8vb1Rr149o/ddEl3nbh06dMB///tffPDBB/om1FZWVggNDS1x+5LO0cnJqdA1VqvVSE5OfvHAi6BUKhEeHo7w8HCo1Wr06dMHc+bMwbRp0wyayBf0xhtvYMOGDfjmm28wbdq0Evfv6ekJALh8+TI6duxosO7y5cv69aYUHx9v0HFdRkYGkpOT0bVrVwDakRnu37+Pbdu2ISQkRF+uqA72nlVJ19PV1RUKhQKXL18utF1cXBwsLCxM/gUJERGVjk3uiYjIZN5//30olUqMGjUKd+7cKbQ+ISEBn3/+OQBtjb6Li0uh3uiXL19u8rh8fHwAwOBY+fn5WLVqVanbymQyCIJgUMuclJSEHTt2FCqrVCqfqef58PBw3Lp1C6tXr8a5c+cMmtsDQJ8+fSCTyfDRRx8VqtUURRH37983+lgFtW/fHi1btsSSJUuQnZ0NNzc3tG/fHl988UWRyXfBocZ0Y8UXdZ4+Pj6F7ueqVauMagnxrJ4+d2trawQGBkIUReTm5ha7Xb9+/dCoUSPMmTNH/7pDQY8ePcKMGTMAAM2bN4ebmxtWrlyJnJwcfZm9e/ciNjYW3bp1M9HZPLFq1SqD+FesWIG8vDx06dIFwJNa74KfB7Va/cLPTWnXUyaT4fXXX8fOnTsNmv/fuXMHMTExCAoK0r92Q0RE5Yc19EREZDI+Pj6IiYlBeHg46tevj4iICDRs2BBqtRq//vorNm/ebDAe+ahRozB//nyMGjUKzZs3x7Fjx3DlyhWTx9WgQQO0bt0a06ZNw4MHD+Ds7IzvvvsOeXl5pW7brVs3LF68GJ07d8agQYNw9+5dLFu2DL6+vvjrr78MyjZr1gyHDh3C4sWL4eHhAW9vb7Rq1arYfXft2hV2dnaYMmUKZDIZ+vbta7Dex8cHH3/8MaZNm4akpCT06tULdnZ2SExMxPbt2/Hmm29iypQpz3VN3nvvPYSFhSE6OhpjxozBsmXLEBQUhEaNGmH06NGoW7cu7ty5gxMnTuDGjRs4d+4cAKBp06aQyWRYsGAB0tLSIJfL0bFjR7i5uWHUqFEYM2YM+vbti9deew3nzp3D/v37C/VxYAqvv/463N3d8corr6B69eqIjY3Ff//7X3Tr1q3ETu+srKywbds2hIaGIiQkBP3798crr7wCKysrXLx4ETExMXBycsKcOXNgZWWFBQsWYPjw4WjXrh0GDhyIO3fu4PPPP4eXlxcmTpxo8vNSq9V49dVX0b9/f1y+fBnLly9HUFAQevToAQBo27YtnJycMGzYMEyYMAGCIGD9+vUv3IzdmOv58ccf4+DBgwgKCsLYsWNhaWmJL774Ajk5OVi4cOELnzsRET0HCXrWJyIiM3flyhVx9OjRopeXl2htbS3a2dmJr7zyirh06VKDYbWysrLEkSNHig4ODqKdnZ3Yv39/8e7du8UOW5eSkmJwnGHDholKpbLQ8du1a1doCK6EhAQxNDRUlMvlYvXq1cXp06eLBw8eNGrYuq+++kr08/MT5XK5GBAQIK5du1YfU0FxcXFiSEiIaGtrKwLQD9VW3LB5oiiKgwcP1g/xVZytW7eKQUFBolKpFJVKpRgQECC+88474uXLl4vdpuBxT58+XWhdfn6+6OPjI/r4+OiHjktISBAjIiJEd3d30crKSqxZs6bYvXt3ccuWLQbbfvnll2LdunVFmUxmcP3y8/PFqVOnii4uLqJCoRA7deokXr16tdhh64qKq6h7J4qF78sXX3whhoSEiNWqVRPlcrno4+Mjvvfee2JaWlqJ10QnNTVVnDlzptioUSNRoVCINjY2YsOGDcVp06aJycnJBmU3btwovvTSS6JcLhednZ3FwYMHizdu3CgUn7GfRVHUDuXXrVs3/e+6a3L06FHxzTffFJ2cnESVSiUOHjxYvH//vsG2x48fF1u3bi3a2tqKHh4e4vvvvy/u37+/0Ge5uGPr1hUcts7Y6/nHH3+InTp1ElUqlahQKMQOHTqIv/76q0GZ4u5vUcNEEhHRixFEkT2TEBEREUkpOjoaw4cPx+nTp/UdGBIREZWG79ATERERERERVUJM6ImIiIiIiIgqISb0RERERERERJUQ36EnIiIiIiIiqoRYQ09ERERERERUCTGhJyIiIiIiIqqELKUOoKLTaDS4desW7OzsIAiC1OEQERERERGRmRNFEY8ePYKHhwcsLIqvh2dCX4pbt26hdu3aUodBREREREREVcz169dRq1atYtczoS+FnZ0dAO2FtLe3lzgaIpJEZibg4aGdv3ULUCqljYdMJlOdCY9Ptff21uRbUFrz3paEjwIREVH5SE9PR+3atfX5aHGY0JdC18ze3t6eCT1RVSWTPZm3t2cWY0Zkahlgo523t7dnQl8KPgpERETlq7TXvtkpHhEREREREVElxISeiIiIiIiIqBJiQk9ERERERERUCfEdehMQRRF5eXnIz8+XOhSzIZPJYGlpyaECiYiIiIiIisGE/gWp1WokJycjKytL6lDMjkKhQI0aNWBtbS11KERERERERBUOE/oXoNFokJiYCJlMBg8PD1hbW7NG2QREUYRarUZKSgoSExPh5+cHCwu+HUISksmArl2fzJPZkFnI0NWvq36eSsZHgYiIqGIRRFEUpQ6iIktPT4eDgwPS0tIKDVuXnZ2NxMREeHp6QqFQSBSh+crKysK1a9fg7e0NGxsbqcMhIiIiIiIqFyXloQWx2tMEWHtcNnhdiYiIiIiIiseMiYiIiIiIiKgSYkJPRFSazExAqdROmZlSR0MmlKnOhHKuEsq5SmSqeW9Lw0eBiIioYmGneERExuBIFmYrK5f39lnwUSAiIqo4WENfRaWkpODtt99GnTp1IJfL4e7ujk6dOuH48eMAAC8vLwiCAEEQoFQq8fLLL2Pz5s3IyclBgwYN8Oabbxba5/vvvw9vb288evSovE+HiIiIiIioymFCX0X17dsXZ8+exbp163DlyhXs2rUL7du3x/379/VlZs+ejeTkZJw9exYtWrRAeHg4fv/9d3z99deIjo7G/v379WVPnjyJzz77DNHR0bCzs5PilIiIiIiIiKoUNrk3IVGUrimiQgEIgnFlHz58iJ9//hlHjhxBu3btAACenp5o2bKlQTk7Ozu4u7vD3d0dy5YtwzfffIPdu3dj3rx5mDFjBkaOHIkLFy7AxsYGw4cPx/jx4/X7IyIiIiIiorLFhN6EsrIAlUqaY2dkaDspMoZKpYJKpcKOHTvQunVryOXyUrextLSElZUV1Go1AGDGjBnYvXs3JkyYADc3NwiCgLlz577IKRAREREREdEzYEJfBVlaWiI6OhqjR4/GypUr8fLLL6Ndu3YYMGAAGjduXKi8Wq3Gp59+irS0NHTs2FG/j6+//hrNmjWDRqPB8ePHYWNjU96nQkREREREVGUxoTchhUJbUy7VsZ9F37590a1bN/z88884efIk9u7di4ULF2L16tWIjIwEAEydOhX/93//h+zsbKhUKsyfPx/dunXT7yMwMBB9+/bFw4cP0bx5cxOeDVEFY2EB6F4nsWDXI+bEQrBAO892+nkqGR8FIiKiikUQRVGUOoiKLD09HQ4ODkhLS4O9vb3BuuzsbCQmJsLb29ssaqdHjRqFgwcP4tq1a/Dy8sKQIUMQGRkJlUqF6tWrQyjiJf3IyEg8fPgQO3bsMHk85nZ9iYiIiIiIjFFSHloQv18nvcDAQGRmZup/d3Fxga+vL9zd3YtM5omIiIiIiEg6bHJfBd2/fx9hYWEYMWIEGjduDDs7O5w5cwYLFy5Ez549pQ6PiIiIiIiIjMCEvgpSqVRo1aoVPvvsMyQkJCA3Nxe1a9fG6NGjMX36dKnDI6p4MjMBLy/tfFKS8UNKUIWXqc6E1+deAICkfyVBac17WxI+CkRERBULE/oqSC6XY968eZg3b16xZZKSkozaV3R0tGmCIqro7t2TOgIqI/eyeG+fBR8FIiKiioPv0BMRERERERFVQqyhJyIiIiIiIvOXkACcPQt4egItWkgdjUmwhp6IiIiIiIjM38GDQFgYUMKrx5UNE3oiIiIiIiIyf1lZ2p8KhbRxmBATeiIiIiIiIjJ/ZpjQ8x16IqLSWFgAzZs/mSezYSFYoLlHc/08lYyPAhERVWpM6ImIqiBbW+D0aamjoDJga2WL06N5b43FR4GIiCo1M0zoK93368uWLYOXlxdsbGzQqlUr/Pbbb8WW/fLLLxEcHAwnJyc4OTkhNDS0xPJERERERERkppjQS2vjxo2YNGkSZs2ahT/++ANNmjRBp06dcPfu3SLLHzlyBAMHDsRPP/2EEydOoHbt2nj99ddx8+bNco6ciIiIiIiIJMWEXlqLFy/G6NGjMXz4cAQGBmLlypVQKBRYs2ZNkeW//fZbjB07Fk2bNkVAQABWr14NjUaDw4cPl3PkRFSpZWUBXl7aSfeHgMxCVm4WvJZ4wWuJF7JyeW9Lw0eBiIgqNSb00lGr1fj9998RGhqqX2ZhYYHQ0FCcOHHCqH1kZWUhNzcXzs7OxZbJyclBenq6wWSubt++jfHjx6Nu3bqQy+WoXbs23njjDf0XHufOnUOPHj3g5uYGGxsbeHl5ITw8vFCLiK1bt6Jjx45wcnKCra0t/P39MWLECJw9e1ZfJjo6GoIgQBAEWFhYoFatWhg+fHixrSuIKhRRBK5d006iKHU0ZEKiKOJa2jVcS7sGkfe2VHwUiIioUmNCL5179+4hPz8f1atXN1hevXp13L5926h9TJ06FR4eHgZfCjxt3rx5cHBw0E+1a9d+obgrqqSkJDRr1gw//vgjPvnkE5w/fx779u1Dhw4d8M477yAlJQWvvvoqnJ2dsX//fsTGxmLt2rXw8PBAZmamfj9Tp05FeHg4mjZtil27duHy5cuIiYlB3bp1MW3aNINj2tvbIzk5GTdu3MCXX36JvXv3YujQoeV96kREREREVBWZYUJfZXq5nz9/Pr777jscOXIENjY2xZabNm0aJk2apP89PT3d6KReFEXJmmwqrBQQBMHo8mPHjoUgCPjtt9+gVCr1yxs0aIARI0bgyJEjSEtLw+rVq2Fpqf2YeHt7o0OHDvqyJ0+exMKFC/H5559jwoQJ+uV16tRBs2bNCtV2CYIAd3d3AICHhwcmTJiADz/8EI8fP4atre1znTcREREREZFRmNBLx8XFBTKZDHfu3DFYfufOHX2SWJxFixZh/vz5OHToEBo3blxiWblcDrlc/lwxZuVmQTVP9VzbvqiMaRlQWitLLwjgwYMH2LdvH+bMmWOQzOs4OjrC3d0deXl52L59O/r161fklwUbNmyASqXC2LFjizxOaV8w2NraQqPRIC8vz6i4iYiIiIiInpsZJvSVpsm9tbU1mjVrZtChna6DuzZt2hS73cKFC/Hvf/8b+/btQ/Pmzcsj1Arv6tWrEEURAQEBxZZp3bo1pk+fjkGDBsHFxQVdunTBJ598YvCFypUrV1C3bl19DT6g7bhQpVLpp7S0tCL3Hx8fj5UrV6J58+aws7Mz3ckREREREREVxQwT+kpTQw8AkyZNwrBhw9C8eXO0bNkSS5YsQWZmJoYPHw4AiIiIQM2aNTFv3jwAwIIFCzBz5kzExMTAy8tL/669Ltk0NYWVAhnTMky+X2OPbSxjO36aM2cOJk2ahB9//BGnTp3CypUrMXfuXBw7dgyNGjUqcpsRI0agR48eOHXqFIYMGWJwrLS0NKhUKmg0GmRnZyMoKAirV682Om4iIiIiIqLnxoReWuHh4UhJScHMmTNx+/ZtNG3aFPv27dN3lPfPP//AwuJJo4MVK1ZArVajX79+BvuZNWsWoqKiTB6fIAhGN3uXkp+fHwRBQFxcXKllq1WrhrCwMISFhWHu3Ll46aWXsGjRIqxbtw5+fn745ZdfkJubCysrKwDa5vqOjo64ceNGoX3Z2dnhjz/+gIWFBWrUqMH35qnyEAQgMPDJPJkNQRAQ6Bqon6eS8VEgIqJKjQm99MaNG4dx48YVue7IkSMGvyclJZV9QJWQs7MzOnXqhGXLlmHChAmF3qN/+PAhHB0dC21nbW0NHx8ffS/3AwcOxNKlS7F8+XL861//KvW4FhYW8PX1Nc1JEJUnhQK4eFHqKKgMKKwUuDiW99ZYfBSIiKjSEkUm9GQ+li1bhldeeQUtW7bE7Nmz0bhxY+Tl5eHgwYNYsWIFPvnkE3z33XcYMGAA6tWrB1EUsXv3bvzwww9Yu3YtAKBNmzaYPHkyJk+ejGvXrqFPnz6oXbs2kpOT8dVXX+nHnCciIiIiIpJUTo42qQeY0FPlV7duXfzxxx+YM2cOJk+ejOTkZLi6uqJZs2ZYsWIF6tSpA4VCgcmTJ+P69euQy+Xw8/PD6tWrDcaOX7RoEVq2bIkVK1ZgzZo1yMrKQvXq1RESEoITJ07A3t5ewrMkIiIiIiIC8Pjxk3kzevVXEI3tIa2KSk9Ph4ODA9LS0golp9nZ2UhMTIS3t3eJY9vT8+H1pQojKwto0UI7f/q0WX2rW9Vl5WahxZfae3t69Oln6mC0KuKjQEREldbNm8UudZYAACAASURBVECtWoCVFaBWSx1NqUrKQwtiDT0RUWlEEbh06ck8mQ1RFHEp5ZJ+nkrGR4GIiCotM3x/HqhE49ATERERERERPRcm9ERERERERESVEBN6IiIiIiIiokqICT0RERERERFRJaRL6M2oh3uACT0RERERERGZOzOtoWcv90REpREEwNPzyTyZDUEQ4OngqZ+nkvFRICKiSosJPRFRFaVQAElJUkdBZUBhpUDSu0lSh1Fp8FEgIqJKy0wTeja5JyIiIiIiIvPGhJ6IiIiIiIioEmJCT+YkMjISvXr10s8LgoD58+cblNmxY4f+ndKtW7dCJpPh5s2bRe7Pz88PkyZNAgC0b98e7777bqEy0dHRcHR0NOVpEJWPx4+BFi200+PHUkdDJvQ49zFafNkCLb5sgce5vLel4aNARESVFhN6Mmc2NjZYsGABUlNTi1zfo0cPVKtWDevWrSu07tixY7h69SpGjhxZ1mESSUOjAc6c0U4ajdTRkAlpRA3O3DqDM7fOQCPy3paGjwIREVVaZprQs1M8ExJFEVm5WZIcW2GleKEemkNDQ3H16lXMmzcPCxcuLLTeysoKQ4cORXR0NKZPn26wbs2aNWjVqhUaNGjw3McnIiIiIiIqM0zoqTRZuVlQzVNJcuyMaRlQWiufe3uZTIa5c+di0KBBmDBhAmrVqlWozMiRI7F48WIcO3YMISEh2uNmZGDLli347LPPnvvYREREREREZcpME3o2uSe93r17o2nTppg1a1aR6wMDA9G6dWusWbNGv2zTpk0QRREDBgwwKLt8+XKoVCqDacyYMWUaPxERERERUZHMNKFnDb0JKawUyJiWIdmxTWHBggXo2LEjpkyZUuT6ESNGYOLEiVi6dCns7OywZs0ahIWFwc7OzqDc4MGDMWPGDINl27Ztw9y5c00SJxERERERkdGY0FNpBEF4oWbvFUFISAg6deqEadOmITIystD6AQMGYOLEidi0aRNCQkJw/PhxzJs3r1A5BwcH+Pr6Gixzc3Mrq7CJiIiIiIiKx4Seqor58+ejadOm8Pf3L7TOzs4OYWFhWLNmDRISElCvXj0EBwdLECVROXNxkToCKiMuCt7bZ8FHgYiIKiUm9FRVNGrUCIMHD8Z//vOfItePHDkSwcHBiI2NxdSpU8s5OiIJKJVASorUUVAZUForkfIe762x+CgQUUUkiiIAvNCIT1QFmGlCz07xqEizZ8+GpphBhoOCguDv74/09HRERESUc2RERERERFpp2WkIXB6I19a/hvScdKnDoYrMTBN6QdR9pUVFSk9Ph4ODA9LS0mBvb2+wLjs7G4mJifD29oaNjY1EEZovXl8iIiIiKsmy35Zh3N5xAIC2tdti3+B9sJPblbIVVUnVqgEPHgCXLgH160sdTalKykMLYg09EVFpHj8G2rfXTo8fSx0NmdDj3MdoH90e7aPb43Eu721p+CgQUUXz1dmv9PO/Xv8VXWO6IkMtzahTVMGZaQ09E3oiotJoNMDRo9qpmFdRqHLSiBocvXYUR68dhUbkvS0NHwUiqkjOJp/F2dtnYS2zxr7B++Agd8Av//yC7jHdkanOlDo8qkg0GiA7WzvPhJ6IiIiIiEhautr5XgG90Mm3Ew4MPQB7uT2OXjuKNza8gazcLIkjpAqjYLMyJvRERERERETSyc7LxrfnvwUAjHxpJACgZc2W2D9kP+ys7fBT0k/o+V1Pvk5FWlkFvtyxtZUujjLAhJ6IiIiIiCqV7bHb8TD7Ieo41MGr3q/ql7eu1Rp7B++F0kqJQ38fQq+NvZCdly1hpFQh6BJ6GxvAwrxSYPM6GyIiIiIiMnu65vaRTSIhs5AZrHulziv6pP5AwgH02dgHOXk5UoRJFYWZdogHMKEnIiIiIqJKJDE1EYcTD0OAgOEvDS+yTLBnML4f9D1sLW2x9+pe9N3Ul0l9VaZ7h54JPRFRFaVQmOUfAQIUVgoorHhvjcVHgYiktvbPtQCAV+u+Ci9Hr2LLtfNqhz2D9sDG0gbfx3+P/lv6Q52vLqcoqUJhDT0RURWmVAKZmdpJqZQ6GjIhpbUSmdMzkTk9E0pr3tvS8FEgIqnla/L1Cb2uM7ySdPTuiN0Dd8PG0ga7Lu/CgC0DkJufW9ZhUkXDhJ6IiIiIiEhaB/8+iBvpN+Bk44ReAb2M2ia0bih2DtgJuUyO7XHbMXDrQCb1VQ0TejI3kZGREAQBgiDA2toavr6+mD17NjZu3AiZTIabN28WuZ2fnx8mTZoEAGjfvj3efffdQmWio6Ph6OhYpvETERERVTUHEw5i/9X9UochKV1neEMaD4GNpY3R273u8zq2h2+HtcwaW2O3Ysj2IcjT5JVVmFTRMKEnc9S5c2ckJycjPj4ekydPRlRUFK5cuYJq1aph3bp1hcofO3YMV69exciRpTdvIjIr2dlAt27aKZtD35iT7LxsdIvphm4x3TiskRH4KBBJJyUzBV1juqLHdz2Q+jhV6nAkkZKZgp1xOwEY19z+aV38umBr/62wsrDCpoubELE9gkl9VWHGCb2l1AGYFVF88mEpbwoFIAjPtIlcLoe7uzsA4O2338b27dvxww8/YOjQoYiOjsb06dMNyq9ZswatWrVCgwYNTBY2UaWQnw/88MOTeTIb+Zp8/BD/g36eSsZHgUg6+67u0yefcffi0KZ2G4kjKn/f/PUNcjW5aFajGZq4N3mufXSv1x1b+m9B3019seHCBsgsZIjuGV1o6DsyM2ac0LOG3pSysgCVSprJBF8k2NraQq1WY+TIkYiPj8exY8f06zIyMrBlyxbWzhMRERFJ4IerP+jn4+7FSRiJNERR1De3f57a+YJ6+PfApn6bYGlhiW/++gYjd43kl7rmTpcr2dpKG0cZYEJPEEURhw4dwv79+9GxY0cEBgaidevWWLNmjb7Mpk2bIIoiBgwYYLDt8uXLoVKpDKYxY8aU9ykQERERma18Tb7Bu/NVMaH/7eZvuJhyETaWNhjYaOAL7693/d7Y0HcDZIIM686tw+jdo6ERNSaIlCokM66hZ5N7U1IogIwM6Y79jPbs2QOVSoXc3FxoNBoMGjQIUVFRAIARI0Zg4sSJWLp0Kezs7LBmzRqEhYXBzs7OYB+DBw/GjBkzDJZt27YNc+fOfe5TISIiIqInTt08hdTsJ+/Nx92vegn9mrPaiqZ+gf3gaGOazpf7BfbDt32+xaBtg7D2z7WQCTJ88cYXsBBY52l2mNCTUQShUg3M26FDB6xYsQLW1tbw8PCApeWTj8OAAQMwceJEbNq0CSEhITh+/DjmzZtXaB8ODg7w9fU1WObm5lbmsRMRERFVFbq+PjzsPHDr0a0qV0OflZuFDRc2AHjx5vZPC28YDo2owZDtQ7D67GpYWlhiebflEJ6xbyqq4Mw4oefXT1WYUqmEr68v6tSpY5DMA4CdnR3CwsKwZs0arF27FvXq1UNwcLBEkRIRERFVXbqEfnzL8QCAhAcJUOerpQypXMWmxOKR+hFcFa4I8Qwx+f4HNhqIdb3WQYCAlb+vxPi94yGKosmPQxJiQk9V0ciRI/Hrr79i5cqVGDFihNThEBEREVU5tx7dwtnbZyFAwIiXRsDO2g75Yj6uPrgqdWjl5lraNQBAXae6ZdYcfkjjIVjbcy0ECFh2ehne3feuPqnXiBqkPk5F/P14nLh+Anuu7MHN9JtlEgeVETNO6NnknooVFBQEf39/XL16FREREVKHQyQdpVI7LCWZHaW1EuIs3ltj8VEgKn/7ru4DALSo2QJuSjcEuATg9K3TiLsXh0DXQImjKx//pP0DAKjjUKdMjzOs6TDki/kYuWsk/vPbf7Anfg8y1Bm4n3Uf+aJhL/jVldVxatQpeDp6lmlMZCJM6MncREdHG1UuLq74d7SOHDlS5PLIyEhERkY+e1BEREREZEDX3L6rb1cAMEjoq4prD7U19J4OZZ88j3hpBDSiBqN3j8bfqX8brLOztoOr0hUZ6gzcybyDbjHd8MuIX0zWSR+VISb0RERERERUnnLzc3Eg4QAAoKvfk4QeqFpD1/2TXj419DqjXh6FEM8Q3Ei/AReFC1wULqhmWw1ySzkA4Eb6DbRa3QoXUy6i76a+2Dt4L6xl1uUSGz0nM07o+Q49EVFpsrOBsDDtlJ0tdTRkQtl52QjbHIawzWHIzuO9LQ0fBaLydfz6cX1ncM08mgGomgm9voa+HJu316tWDx29O6Jx9cbwsPPQJ/MAUMu+Fr4f9D1U1ir8mPgj3trzFjvRq+iY0BMRVWH5+cCWLdopP7/08lRp5GvyseXSFmy5tAX5Gt7b0vBRICpfuub2nX076zuDK5jQV5UkUvcOfXk0uTdWU/em2NhvIywEC0T/GY05P8+ROiQqCRN6IiIiIiIqT/r35//X3B4AfJ19IRNkeKR+hOSMZKlCKzdZuVlIyUoBUH5N7o3V1a8rlnVdBgD48KcP8c1f30gcERWLCT0REREREZWXaw+v4WLKRVgIFnjd53X9cmuZNXycfQBUjWb319OuA9B2SFcRO58b03wM3mv7HgBgxM4ROJp0VOKIqEhM6ImIiIiIqLzsvboXANCmVhs42zobrNM1u49NiS33uMqbbgz6Og51IAiCxNEUbX7ofPQL7IdcTS56b+xdJb5oqXSY0BMRERERUXkpqrm9TkC1qtMxnv79+Qo83ruFYIGve32N1rVaIzU7FUO3D5U6JCooN1c7AUzoiYiIiIiobGXnZeNw4mEAxST0uo7x7pt/Qq/r4b6OfcV6f/5ptla22B6+HTJBhjO3zhQaw54k9Pjxk3km9EREREREVJaOXTuGrNws1FDVQJPqTQqtr0pD1+nGoK/INfQ67ip3hHiGAAB2xu2UOBrS0zW3FwRALi+5bCXEhJ6IqDQKBZCRoZ3M8JvdqkxhpUDGtAxkTMuAwor3tjR8FIjKR8Hm9kW9N+7v4g8AuJF+A49yHpVrbOVNX0NfwXq4L05P/54AgJ2XjU/oUzJT0GxVM0zYO6HKDEVYrgq+P19B+2F4EUzoq6jIyEgIggBBEGBtbQ1fX1/Mnj0beXl5OHLkiH7d09Pt27cBAFFRURAEAWPGjDHY759//glBEJCUlAQASEpKgiAIcHNzw6NHhn9wmjZtiqioqPI4XaIXIwiAUqmdzPAPQVUmCAKU1koorZUVtrOlioSPAlH5KOn9eQBwtnWGm9INAHDl/pVyi0sKFXEM+pL0DNAm9D//8zPuZ903apu1f67FH8l/YOlvS/HxsY/LMryqyYw7xAOY0FdpnTt3RnJyMuLj4zF58mRERUXhk08+0a+/fPkykpOTDSY3Nzf9ehsbG3z11VeIj48v9ViPHj3CokWLyuQ8iIiIiMzF1QdXEf8gHpYWlgitG1psuarQ7D5fk4/r6dph6ypLDb2XoxeaVG8CjajBnit7Si0viiLW/7Ve//vMIzOx6eKmsgyx6mFCT0YTRSAzU5rpOZrnyOVyuLu7w9PTE2+//TZCQ0Oxa9cu/Xo3Nze4u7sbTBYWTz4y/v7+6NChA2bMmFHqscaPH4/Fixfj7t27zxwnkeRycoDISO2UkyN1NGRCOXk5iNwRicgdkcjJ470tDR8ForK3N147XF1wnWDYy+2LLVffpT4A807ob2fcRp4mDzJBBg87D6nDMdqzNLs/d+ccLty9AGuZNUa9NAoAMGzHMJy+ebpMY6xSmNCT0bKyAJVKmkn3QX0Btra2UKvVz7TN/PnzsXXrVpw5c6bEcgMHDtQ36yeqdPLygHXrtFNentTRkAnlafKw7tw6rDu3Dnka3tvS8FEgKlt3Mu5ga+xWAMU3t9fRj0V/z3zHoteNQV/LvhZkFjKJozGertn9/oT9eJz7uMSy689pa+ffqPcGVnZfiW5+3ZCdl40e3/XA9bTrZR5rlcCEnsydKIo4dOgQ9u/fj44dO+qX16pVCyqVSj81aNCg0LYvv/wy+vfvj6lTp5Z4DEEQMH/+fKxatQoJCQkmPwciIiKiyiI7Lxtnk89i3Z/rMHn/ZLy2/jVUX1Qd7p+64+i1owCALr5dStxHVWhyXxnGoC/KS+4vobZ9bWTlZuHQ34eKLZenyUPMhRgAwNDGQyGzkCGmbwwaujXE7Yzb6PFdD2SoM8orbPOlG7bOTBN6S6kDMCu67n+lOvYz2rNnD1QqFXJzc6HRaDBo0CBERUXh9GltE5+ff/4ZdnZ2+vJWVlZF7ufjjz9G/fr1ceDAAYN37J/WqVMnBAUF4cMPP0RMTMwzx0tERERUmYiiiJuPbuKvO38ZTHH34pAv5hcqL0CAXzU/9A7ojUDXwBL3rUvo4x/EI0+TB0sL8/tvfWXr4V5HEAT09O+J/57+L3Ze3ok3/N8ostyPiT/idsZtVLOthi5+2i9w7OX22D1wN1p+2RJ/3v4TQ7cPxdb+W2EhsB72uZl5Db35PflS0nX/W0l06NABK1asgLW1NTw8PGBpafhx8Pb2hqOjY6n78fHxwejRo/HBBx/gq6++KrHs/Pnz0aZNG7z33nsvFDsRERFRRZKVm4ULdy8USt5Ts1OLLO9k44Qm7k3Q2K0xGlfXToGugVBaG/d/yToOdWBjaYPsvGwkPUyCr7OvKU+nQqhsPdwX1DNAm9DvvrIb+Zr8Il8Z0HWGF94gHNYya/1yL0cv7BiwAx3WdcCOuB2Yfng65ofOL7fYzQ4TejJXSqUSvr6m+cd/5syZ8PHxwXfffVdiuZYtW6JPnz744IMPTHJcs6DRABMnAtbWwMKFHAuKiIioktgWuw0bLmzAX3f+Qvz9eIgo3EmxTJAhwCVAn7Trppp2NV9ouEwLwQL+1fxx7s45xN2LM8uEXvcOfWWroQeAdp7t4CB3wN3Muzh18xTa1m5rsD5DnYFtsdsAAEObDC20fdvabbGmxxoM2T4EC44vQIBLACKbRpZH6OaHCT1VVXfv3kV2drbBsmrVqhXZ9L569eqYNGmSwbB3xZkzZw4aNGhQqEVAlXXoEPCf/2jnmzcHwsOljYeIiIhKlZ6TjoFbB0Kd/6RD4erK6oUS9/ou9SG3lJdJDAEuAfqEvnu97mVyDClV5hp6K5kVutXrhpjzMdgRt6NQQr89djuycrPg6+yLVjVbFbmPwY0HI/ZeLOb8PAdv7n4TPk4+CPYMLo/wzYuZJ/R8GYOK5e/vjxo1ahhMv//+e7Hlp0yZApVKVep+69WrhxEjRhT6sqDK+u9/n8xPnixdPwxERERktMN/H4Y6Xw1PB08cHHoQtyffxu0pt3Fg6AEsen0RIppEoKl70zJL5gHzH7quMtfQAyUPX6drbj+k0ZASW2rM7jAb/QL7IVeTi94be+Pv1L/LJlhzZuYJPatIq6jo6Ohi17Vv3x5iKePaR0VFISoqymCZvb09UlJSDJZ5eXkVua8vvvgCX3zxhdHxmq3ERGDPHu18jRrAzZvAxx8D8/meVIWiUAB37z6ZJ7OhsFLg7pS7+nkqGR8Foid+iP8BANAroBdC64ZKEoM593Sflp2G9Jx0AJU3oe/s2xlWFla4cv8K4u7F6e/XrUe3cDjxMABgSOMhJe7DQrDAul7rkJiaiN+Tf0f3mO44MfIEHGwcyjx+s2HmCT1r6ImktHw5IIrA668Dui84Fi8GLl+WNi4yJAiAq6t2Yh8HZkUQBLgqXeGqdH2hd1mrCj4KRFqiKGLv1b0ASh9eriyZc0Kvq52vZlvN6I4CKxp7uT06emuHhN4Z96SWPuZ8DDSiBm1rt4WPs0+p+1FYKbBzwE542Hkg9l4swreEI0+TV2Zxmx0m9ERUJrKyAN2oAOPHA927A127Arm5wIQJ2kSfiIiIKpzzd8/j5qObsLW0RTuvdpLF4VfNDwIE3H98HymZKaVvUIlU1jHon9YroBcAYMflHfpluub2QxsX7gyvODXta2L3wN1QWCmwP2E/Ju2fZNpAzRkTeiIqEzExQGoq4O0NdOmire76/HNtb/cHDgA7dpS+DyofOTnAO+9op5wcqaMhE8rJy8E737+Dd75/Bzl5vLel4aNApLU3Xls739G7I2wsbSSLQ2Gl0Ce85lZLX1nHoH9aD/8eAIBTN07hdsZt/XCG1jJr9G/Q/5n29XKNl7G+t/bLgKW/LcWK0ytMHq9Z0iX0trbSxlFGmNATSUEUn3SGN3YsIPvf2KS+vsB772nnJ0588g8QSSsvT/t6xPLl2nkyG3maPCw/sxzLzyxn80Uj8FEg0vrhqvb9eSmb2+uYa7P7ytzDfUEedh5o4dECIkTsvrwb689pE/Juft3gbOv8zPvrU78P5nacCwAYv3c8DiYcNGm8Zok19FSa0jqQo+dj1tf1+HHg3DntN4UjRhiumz4dqFMHuHaNneMRERFVMGnZaTj+z3EAQBe/CpDQVzPPhL6y93BfkK63+21x2xBzIQbAszW3f9oHQR8gokkE8sV8hG0OM7t7b3JM6Kk4uvHYs1iLWiZ017Woce8rvaVLtT8HDwacn/p2VqEAPvtMO79wIZCQUL6xERERUbEO/n0Q+WI+/Kv5o65TXanDQX3X/w1dd9+8kroKW0OfmwtERDzpzNgIuvfo913dh1uPbsHJxgld/bo+dwiCIGBV91V4pfYrSMtJQ/eY7rifdf+592f2zDyh57B1L0Amk8HR0RF3/zeGj0KhYC/JJiCKIrKysnD37l04OjpCpmuObi5u3gS2bdPOjxtXdJnevYHXXgMOHgTefRfYvbv84iMiIqJi6d6ff5GEzJTMtcl9ha2hP3MGWL9eO+zwm28aNeRHoGsgfJx8kJCqraQJbxAOuaX8hcKQW8qxPXw7Wq5uiYTUBPTd1BcHhh6Atcz6hfZrlpjQU0nc3d0BQJ/Uk+k4Ojrqr69ZWbVK+/JpcDDQpEnRZQRBW4vfqJH2D8aePdpe8ImIiEgyFWW4uoJ0CX1iaiKy87Il7aTPVNT5aiQ/SgZQAXu5f/BA+zM1Fbh7F6hevdRNBEFAT/+eWHxyMQBgaJPnb25fkKvSFXsG7kGbr9rg6LWjeHvP21jdYzUrGJ/GhJ5KIggCatSoATc3N+Tm5kodjtmwsrIyv5p5AFCrnzTRKq52XsffX9sx3sKF2p9duwIWfEuGiIhIKufunENyRjIUVgqEeIZIHQ4AwFXhCicbJ6RmpyL+fjwaVW8kdUgv7Eb6DYgQYWNpA1eFq9ThGHr48Ml8bKxRCT0A9G/QH4tPLkaASwDa1GpjsnAauDXAxn4b0X1Dd6z5cw3qu9bHlLZTTLZ/s8CEnowhk8nMMwEl09qyBbhzB/Dw0DarL82HHwLLlgFXrwLnzxdfo09ERERlTtfc/lXvV1+4ybSpCIKAAJcAnLhxAnH34swioS84ZF2Fq21OTX0yHxsLtG9v1GatarXCL8N/KZNz6uLXBYtfX4x397+L9w++j3rV6umHyyOYfULP6j6i8qTrDG/MGMCYzv5UKqBdO+38QQ5LIhlbWyAxUTuZ6RimVZWtlS0S/5WIxH8lwtaK97Y0fBSoqqtIw9UVpGt2H3svVuJITEPXIV6Fe38eKFxD/wxeqfMKajvUNnFAWhNaTcBbzd6CCBGDtg7CudvnyuQ4lY4oGiT0l1IuYeHxhTj892Fp4zIhJvRk3kQRyM+XOgqtM2eAkye1ifzo0cZv99pr2p9M6KVjYQF4eWknvvZgViwEC3g5esHL0QsWAu9tafgoUFWW+jgVJ66fAFAxhqsryNw6xtN1iFfhergHXiihL0uCIGBpl6V41ftVZOZm4o0Nb+B2xm2pw5KeWg1oNNp5hQLHrh3D1ENTseTUEmnjMiH+OSbzJYra2u369YHkZKmj0TadB4CwMOBZOvt7/XXtz2PHgOxs08dFREREpdINV1ffpT68HL2kDsdAfZf/DV1nJgl9ha6hf7rJfQViJbPC5rDNqFetHq6nX0ev73rhce5jqcOSVsHhxRUKXLl/BQDgX81fooBMjwk9ma+UFODnn4H4eGDgQG3P8lJ59AjYsEE7P378s21bv772nfvsbOCXX0wfG5VOrQbee087qdVSR0MmpM5X470D7+G9A+9Bnc97Wxo+ClSV6Xq3ryjD1RWkq6G/fP8yNKJG4mheXKWpob95E0hPly6WIjjZOmHPwD1wsnHCqZun0Gtjr6pdU69L6C0tASsrfUJfr1o9CYMyLSb0ZL6uXHkyf/SotoM5qRw6BOTkAL6+QKtWz7atILDZvdRyc4FFi7QTR7MwK7n5uVh0YhEWnViE3Hze29LwUaCqSiNq9B3iVbT35wHA28kb1jJrZOVm4XradanDKdGN9Bu4l3WvxDIVuoa+YEIPVLhaegDwq+aHrf23Qi6T40DCATRc3hBbLm2ROixpPNUh3uX7lwEwoSeqHHQJvev/hjuZP187nrsU9mr/E4Bu3bQJ+rPSNbs/cMB0MREREZFR/rz9J+5k3oHKWoWgOkFSh1OIpYWlPkG5lHJJ4miKtz12O3z+44MWX7Yo9ktUURT1CX2FG4MeeNLkXje6VQVM6AGgg3cHnHnzDJq6N8X9x/cRtjkMg7cNRurj1NI3NicFEnp1vhqJqYkAmNATVQ66hL5/f2DCBO18RASQlFS+cYgi8IO2V1x0ec5v9UNDtT///BO4e9c0cREREZFRfojX/h2vSMPVPa2BawMAwMWUi8+03ZlbZ7AtdhtuPbpVFmHprT+3HmGbw6DOVyPpYRL2XCm6kiUlKwXZedkQIKCWfa0yjem56GrodUMJV9CEHgAaujXEqVGn8H/B/wcLwQIx52PQaEUjHEioQhVEBRL6xNRE5Iv5UFopUUNVQ9q4TIgJPZmv+HjtTz8/4JNPtE3dU1O1ndLl5JRfHOfPa9+xsrV9MgTds3Jze/KH47D5DLNBRERUGejen6+Ize11Al0DATxbDf3D7IcIWRuCvpv6oubimvBa4oXB2wZj2W/LcDb5LPI0pul/aPnp5YjYEYF8MR817WoCAFaf1hyIeAAAIABJREFUXV1kWd0Y9DXsasBaZm2S45uUroa+bVvtzwqc0AOAtcwa/+74bxwfcRx+zn64+egmOn3TCWO/H4tMdabU4ZW9Agl9wffnhedpMVtBMaEn86Wroa9XD7C2BjZtApydtcPHTZpUfnHomtt37AjY2Dz/ftjsnoiIqNw9ePwAJ2+cBFDxhqsr6HkS+r/u/IXHeY9haWEJC8EC19KuIeZ8DMbtHYeXV70MpwVOCP06FLN+moX9V/cjLTvtmeNa8MsCvPPDOwCACS0n4HCEtmJi39V9uJF+o1B5fXP7itghnkYDpP3vGrRpo/1ZwRN6nda1WuPPMX9iXItxAIAVZ1Zg2I5hEkdVDopJ6M0JE3oyTxrNkxr6ev97aOvUAb75Rju/fPmTXufLmq65fdcX7BW3YMd4ovhi+yIiIiKjHEg4AI2oQQPXBhWzk7b/KZjQi0b+P+GvO38B0LY8SJ2aigNDDiCqXRRe93kddtZ2yFBn4HDiYcw+Nhudv+0MpwVOaLyiMcbsGYOvz32NhAcJxR5LFEXMODwDHxz+AAAwI3gGlnReAn8Xf7TzbAeNqEH0n9GFttP1cF8hr/WjR0/+D6ZL6P/+u9IMK6ywUmBp16X4ftD3AICdl3ea/zv1TOiJKqnr17XN6q2sAM8C3/B26QL83/9p50ePLvtvVdPSgOPHnxz7RQQFAXK5tvl+Jfk2mIiIqLKryMPVFeTr7AtLC0s8Uj/CzUc3jdpGl9A3rt4Y9nJ7vObzGma1n4X9Q/YjdWoqzo05hxXdVmBI4yGo61QXIkScv3seX/z+BYbtGAbfpb6o8WkN9NnYB4t+XYRfr/+KnLwcaEQN/rXvX5j7y1wAwPxX5+Pjjh/rmzmPfGkkAOCrs18VGmavQtfQ65rby+WAlxfg4GBYiVRJdPXrigauDZCnySu2LwOzUTChf2CeCb2l1AEQlQndP6x162rHnSwoKgr49Vfgxx+Bfv2A334DlMqyiePgQSA/HwgIALy9X2xftrZASIh2nwcPAoGBpomRSmdrC1y48GSezIatlS0uvH1BP08l46NAVY0oith3dR+Aiv3+PKB9V9rP2Q+x92JxKeWSUR3KFUzonyazkKFx9cZoXL0xxjQfAwC4nXEbv17/VT+duXUGdzLvYHvcdmyP266Pw8vRS18buqzrMoxtMdZg330D+2L83vFIepiEHxN/RGjdUP26Cl1Dr+sQz8lJO2pR/frAyZPaipZGjaSN7Rn1DuiNiykXsT1uO4Y2GSp1OGXHoIb+TwDml9Czhp7MU8H3558mkwEx/8/eeYdHUXZt/N6S3ZAGBAgJNYTehFAVpFeFD6QjiIICNsQGKOorKCoIWFCwACqiqIAiKoiAdBQJvYYaQiCEFFpI3Wz5/jhMdhOSrbM7s5Pzu6695kkyO/Mkm9md85z73OcHICoKOHkSePJJ70nYhfp5T+X2AtyPXhrUaqBpU3qo+W1TSahVajSNaIqmEU2hVvFr6wi+FJiyxqmMU0jLTkOgNhAdanaQejoOcaWO3mwx41jaMQAlB/QlERkSicGNB2N+7/n494l/kTk9E7vH7cb7Pd/HwIYDUSWoCgwmA85cOwO1So3lDy2/K5gHSPo9uvloAJSlt0XWLeuEgL5CBdo2bkxbP1RODm48GAB5GeQU5Eg8Gy+SmwsAKAgMKOzkwAE9w/gD9gJ6AKhaFVi5koL7FSuAxYvFn4MY7eqKIwT027cDBoM4x2QYhmEYpkR2XNwBALivxn2ybVdniysBfcKNBOQU5CBQG4h64fXcOl+gNhAda3XEtI7TsHbkWqROScWZSWew/KHl2DVul93M7xOtSHa/Jn4NruVcK/y+4HIvywy9ILlXQEDfMrIlapevjVxjrrLb2N3J0N9UFwAAIoIjUCGwgpQzEh0O6BllUtwQryQ6dQJmz6bx5MnAgQPizuHwYeDqVZLzd+okzjHvuYda2GVnA3v2iHNMxjEGA5VqzJzJCykKw2AyYOb2mZi5fSYMJn5tHcGXAlPW2HlxJwCgS2032876GFd60Qty+6ZVmkKrFqcKV6VSoX6l+hjTYoxDRUOrqFaIjYyFwWTA90fJtDjbkI1ruRTcy7KG3lZyD1gD+pPOdxaQCyqVCoMaDQJAiyqK5U5Afx2UqVdadh7ggJ5RKkKGvn59+/tNmQIMGEB3psOGWVdexUCQ2/foQeYpYqBWAz3v1Jmx7N53FBQAb71Fj4ICqWfDiEiBqQBv7XgLb+14CwUmfm0dwZcCU5awWCyFAX3n2p0lno1zuOJ0b69+3leMbzUeAPWkt1gshXL7MH0YygeWl2xepVKa5P7MGfJM8jMGNaaA/o8zf3j8GXg99zpe+OsFzP93Ps5fPy/G9MThTkCfarkNAGgQzgE9w8gfgwG4cIHG9jL0ABmaLFtGhnUXLgBjx4pXTy9Wu7ricD96hmEYhvE6F25eQPLtZASoA9C+Rnupp+MUDSo1gFqlxs28m7iaddXuvnII6Ec1H4VAbSCOpx3Hviv75O1wD9wtuY+OBgIDqbOScO/pR3Ss2RFVgqrgZt7NwvISd7iZdxO9v+uNBXsXYOrmqaj3aT20/KIl3t7xNo6nHXe6jaJXuBPQp5hvAeAMPcP4Bxcu0CppUBBQrZrj/StWBFavBnQ64PffgfnzPZ/DjRtWSbxY9fMCQoZ+/37g+nVxj80wDMMwDABgRyIFOG2rt0VQQJDEs3EOvVZfWA/vqI5eDgF9hcAKGNpkKABg6cGl8na4B+6W3Gs0QMOGNPbDOnqNWoOBDQcCAH6N/9WtY9zOv40HVzyIAykHUDmoMrrX6Q6NSoMjqUcwY/sMNP+8ORotaoTpf0/HvuR9vg/u7wT0l410z8wBPcP4A7b183f6nTqkdWvgk09oPH06sGuXZ3PYtIn6kjZtCtQS+UOpenVqWWexUOs9hmEYhmFEZ2eSf9XPCzhjjJdlyML5GySLbh4hbbu18bEku//x+I+Fc5Zthr645B7wa2M8wCq7//XUrzBbzC49N6cgB//34/9hz+U9qBhYEX+P+RtbHt2Cq1Ou4usBX6N/g/7QaXQ4c+0M5vwzB+2WtkPtj2vj+Q3PY0fiDpjMPihTuBPQXzRkAOCAnmH8A2fr54szcSIwejRl90eMAFJT3Z+Dt+T2Aiy7ZxiGYRiv4m/18wJNKjsO6I+nHQcARIVEoUpwFZ/MqzQ61+6MeuH1kGXIwteHvgYg4wx9cck94PcBfY86PRCqC0VKVgrikuOcfl6eMQ+DVg7Cjos7EKYPw8ZHNqJFZAsAQOWgyhgXOw5/PPwH0qem46chP2F40+EIDgjGpcxL+CTuE3T9tiuiPojChN8n4K9zf3nPmPZOQH9NlQsVVKgbXtc755EQDugZ5eGoZV1pqFTAF19Q9jslBRg1yj2DE7MZ+OsvGosttxew7UcvZV0SwzAMwyiQy5mXkXAjAWqV2i/6z9tSmKHPKD2gl4PcXkClUuGJWGphd9tAxmWy7EEP3C25B/w+oNdr9XiwPiWgnJXdG0wGDF89HJvOb0JwQDD+HPUn2lZvW+K+YfowjGg2AiuHrkT61HT8NvI3PNbiMVQMrIj0nHQsPbQUD6x4AFXmVcEjax7Bmvg1yDZki/b7CQF9TgD9XwVqA8U7tkzggJ5RHu4G9AAQEgL8/DO1mtu6lXozucrBg0BaGhAaCnTs6PrznaFLFyAgAEhMBM7LyEmUYRiGYRSAkJ2PjYxFmD5M4tm4hjOSezkF9ADwWIvHoFFpCr+WbYbekeTeT5MsgxsPBkCye0c17kazEaPXjMYfZ/5AoDYQfzz8BzrWcu5+t1xAOQxoOADLHlqG1Cmp2DxmM55u8zQiQyKRmZ+JFcdWYMiqIagyrwoGrxyM749+j5t5Nz375WwCeiXK7QEO6Bkl4kwPens0bgwsWULjd96xtp9zFmH/Xr3IaM8bBAdbFwtYdu99AgOBuDh6BCpvZbcsE6gNRNz4OMSNj1Pkqr3Y8KXAlBX8rf+8LY0qN4IKKmTkZCAtO63EfeQW0EeFRqF/g/6FX8u2hr4kyX39+tRWODOTFJ5+yAP1HoBeo8fZ62ftLgSZzCaMXTsWP5/8GTqNDr+O+BXd6nRz65wBmgD0jOmJz/p9huSXkvHP4//g5fteRnSFaOQac/HrqV8x5tcxiJgXgc/2febur1YY0OdqldmyDuCAnlEa2dnA5cs0drWG3paHHwaeeYbGjzwCJCU5/1yhft5bcnsBW9k94100GqBtW3poNI73Z/wGjVqDttXbom31ttCo+bV1BF8KTFnBX+vnAcqCxlSMAVBylt5iscguoAdQKLsPUAcgMiRS4tmUQkmSe70eqHunLttPZfeh+lD0jKEuSmvi15S4j9lixpPrnsSKYyugVWuxaugq9K3XV5TzC6Ut83vPR8LkBByceBBvdHoDjSo3QoG5AB/995H7B+cMPcP4GefO0TY8HKhUybNjffgh0KYNtYYbPpz62zsiIwPYu5fGvgrot24FjEbvnothGIZhyghp2WmIz6DA7P5a90s8G/ewJ7u/lHkJt/JvQavWolHlRr6eWqk8WP9BvHjvi/iwz4fyXGAtKKDEEVA0Qw/4fR09AAxqZHW7L47FYsHkDZPx1aGvoFapsWLwCgxsNNAr81CpVIiNisWs7rPw3xP/QaPS4Nz1c0i8mejeAW0C+oaVG4o3URnBAT2jLDyV29ui11N/+ooVKUifOtXxczZtovqpe+6h9nLepFUrWrjIzCT9K+M9DAZg3jx6OLOww/gNBpMB8/6Zh3n/zPOew66C4EuBKQvsukita5tFNEOlIA+TAxJhL6AXsvONKzeGTuOl0kA30Kg1+LDPh5jUbpLUUymZmza13OXLF/2ZENCfLF2uLncGNBwAtUqNQ1cPFQmeLRYLpm2ehkX7FkEFFb4Z+A2GNx3ukzmVDyyP9jXaAwA2n3dPkWrhDD3D+BnutqwrjehoYPlyGn/yCQX49vB2uzpbNBqgRw8as+zeuxQUANOm0aOgQOrZMCJSYCrAtL+nYdrf01Bg4tfWEXwpMGWBQrl9Lf+T2ws4E9DLSW7vFwgBfWgooNUW/ZkCMvRVgqugU61OAIC1p9YWfn/G9hmYv2c+AOCL/l/g0RaP+nRevWOoVfPmBDfudc1mqHJzAQCmQB1qhtUUc2qygQN6Rll44nBfGv37A6++SuMnnrCeQ8BiAQ4cAF55BVh75w3QFwE9YJXdszEewzAMw4jCzqQ7hnjR/meIJ+BMQN88orlP5+T3lORwL9CE/t7+HNADVtm9UEc/e9dszNo5CwCwoO8CTGw90edz6lWX7nW3XNgCk9nFdtJ5eYXDyIgYeZZyiAAH9Iyy8EZADwCzZlGruNu3gaFDqR7n0CFg+nSgXj2qtZ87l2qr6tUD7r1X3POXhhDQ790L3Lrlm3MyDMMwjEK5mXcTR64eAYDCbKU/ItTGp2an4lrOtSI/4wy9mwgO97aGeAKN7ngRpKZa9/NDHmr0EABgd9JuvLH1Dby29TUAwPs938fk9pMlmVO76u0Qpg/D9dzrOHT1kGtPviO3B4DaUfLxixAbDugZZSFmDb0tWi3w449A1arAsWNAtWpUwz5nDpCQAJQrBwwbRpL8I0eoR7wviI6m8gKTCdi+3TfndJWCAmDMGFrwYBiGYRgZ80/SP7DAgvrh9REVGiX1dNwmRBdS2PpNMPgDgDxjHk5fOw2AA3qXsZehDw0FatSgsTtZerMZeO01YP169+cnArUr1EbrqNawwIJ3d70LAJjZZSamdZwm2Zy0ai26RVNrvE3nXVSk3gno8zRAvSrKNMQDOKBnlMT16+QyD1CWXGyiooCffqJeo7duURPmIUOAlSuB9HRg1SrK3gcFiX9ue8hddr9zJ/D998AbbxSRPjEMwzCM3NhxcQcA/2xXV5ymEU0BACfSThR+72T6SZgtZoSXC0e10GpSTc0/sRfQA57V0W/ZAsyeTQkQiQ1KBNk9ALzS8RW82eVNCWdD9Iqhe12X6+jLgCEe4IcB/aJFixAdHY3AwEC0b98ecXbcvU+cOIEhQ4YgOjoaKpUKH3/8sQ9nyvgcITtfrRoQEuKdc3TtCmzbRpn49HTg55+ppV1wsHfO5wy9ySxEtsZ4+/bRtqCAvAYYhmEYRqYIhnhdavtv/bxAk8p319Hbyu1VKpUk8/Jb7EnuAc8C+lOnrOfYutX154vI47GPo3VUa/yv8/8wu8dsWfyfCHX0/yT9g2xDtvNP5IBefqxcuRIvvfQSZsyYgYMHD6JFixbo06cP0tLSStw/JycHMTExmDNnDiIjI308W8bneKt+vjidO1Mm3luLBq7StSs53p89CyQmSj2bu9m/3zres0e6eTAMwzCMHbIMWTiQQgvPSsjQFxrjZVgD+mOpxwAA90Sw3N5lvJmhtzVcdtRRyctEhUZh/8T9eLvb27II5gGgfnh91C5fGwXmgsJFN2fIz6RFGA7oZcSHH36ICRMmYNy4cWjSpAm++OILBAUF4euvvy5x/7Zt22LevHkYOXIk9Hq9j2fL+Bxv1c/LnfLlrSZ8cszSCxl6APj3X+nm4QmBgaTM2LaNxoxiCNQGYttj27DtsW0I1PJr6wi+FBgl89/l/2A0G1GrfC3UrlBb6ul4TElO90fT2BDPbYQMvTcCeuEeFgB+/VVy2b3cUKlUbsnuU9LOAwDy9WpUCarilbnJAb8J6A0GAw4cOICePXsWfk+tVqNnz57YI2LWLz8/H5mZmUUejJ8gdg96f0Koo5dbQJ+WBiQlWb/es4fa/PkbGg0pIQQ1BKMYNGoNukZ3RdforoptZyMmfCkwSmZHonLq5wGgcRUKMK/cvoKbeZRdZod7DxAy9I4k94mJRdzVncI2Q3/9Oq2aMkUQZPeuGONdTU0AAFjKlZON2sAb+E1An5GRAZPJhKpVqxb5ftWqVXH16lXRzjN79myUL1++8FGzZk3Rjs14GV9J7uWIENBv2UKO93JByM7XqUPO/1evyrMsgGEYhinzFPafV0D9PACE6cNQI4yc1+PT45GalYq07DSooCo0zGNcwJHkvkoVIDycEhenTzt/3Px84OJFGg8cSNtVq9yfp0LpUacHVFDhRPoJXLl9xannpGXQ31UdEurNqUmO3wT0vmL69Om4detW4ePSpUtST4lxBoul7EruAaBdOyAsjFZ1Dx6UejZWhPr5++8HYmNp7I919AUFwKJF9GAZnKIoMBVgUdwiLIpbhAITv7aO4EuBUSp5xjzsvbwXgHIy9EBR2b2Qna9fqT6CAnzckUcJOJLcq1Tuye4TEqhtXUgI8Nxz9D2W3d9FpaBKaBXVCgDwd8LfTj3n+jWK43Qh5b02LzngNwF95cqVodFokJqaWuT7qampohre6fV6hIWFFXkwfsDVq0BWFrWUi4nx7rlWrwZWrJCXdFyrBbp3p7GcZPdChr5NG6BDBxr7Yx29wQBMmkQPg0Hq2TAiYjAZMGnDJEzaMAkGE7+2juBLgVEq+5L3Id+Uj6rBVVE/XDmle7ZO9yy39xBHknvAvYDeNiHVpQtl+ll2XyKu1tHfvE6Z/MCwcK/NSQ74TUCv0+nQunVrbNmypfB7ZrMZW7ZswX333SfhzBhZIMjto6MBnc5759myhdrUPfII8Npr8grq5VZHb7FYA/q2bQHhOvXHDD3DMAyjaGz7zyup1rawF336CashHjvcu4cjyT3gXkBv6wGl1QKDB9PXErvdy5HedalV8+bzm2Fx4h789k3qhBZcXrmGeIAfBfQA8NJLL2HJkiX49ttvER8fj6effhrZ2dkYN24cAODRRx/F9OnTC/c3GAw4fPgwDh8+DIPBgOTkZBw+fBjnzp2T6ldgvIUv6udzc4Enn7R+PWeOvIJ6oR/9P/+QWkFqLl8mUzyNBmjZ0pqhP3IEyHahhyjDMAzDeBkl9Z+3pSTJPWfo3cBicSy5B4Am9PfGyZOl71Oc4iWjw4bRlmX3d9GhZgcEBQQhNTsVx9KO2d33Ru4NWO7cb4ZWVHb7cr8K6EeMGIH58+fjzTffRMuWLXH48GH89ddfhUZ5SUlJSElJKdz/ypUriI2NRWxsLFJSUjB//nzExsZi/PjxUv0KjLfwRf38rFnA+fNA9eoUzAPyCurr1iWFQkEBsNP5Hp1eQ8jON2sGlCsH1KhBD5OpaCs7hmEYhpGYuOQ4AEDHWh0lnom4NK5MGeNLmZdwIu0EAA7o3SI31xpc25PcN2tG2zNngLw8545dvEtTly5A5crAtWvA9u1uTVep6LX6Qo+LzeftK1LPXj+LoDsvmS6Ua+hlxaRJk3Dx4kXk5+dj7969aN++feHPtm/fjmXLlhV+HR0dDYvFctdjO18cysPbGfqjR4F582i8aBHwyivAp5/S13PmAK+/Ln1Qr1JZZfebnG/p4TVs5fYC/lxHzzAMwygSo9mIW/m3AKDQFV4pVCxXEVEhUQCAAnMBQnWhqF2htsSz8kMEub1aTeZ1pVG9Ojndm0zOZ+mLJ6VYdm8XZ+voz1w7g3LGO18EKdsE0u8CeoYpEW/2oDeZgAkTAKMRGDLE2lJk0iRrUD97tjyCekF2L4c6esHh3jag5zp6hmEYRmZk5mcWjsvrlZfJE2T3ANC8anOoVXz77zK2cnt7HgsqFXDPHQXE0aOOj5udDSQn09j2HlaQ3a9Zw7L7YggB/c6LO5FnLF0FcebamcIMPQf0DCN3TCaSwgPeydB/9hkQF0dt4T75pOjPJk2yfm/2bOCNN6QN6rt3pw+TkyetHxBSYLGUHNALGfo9e6Rf/GAYhmEYADfzKPsaFBCEAE2AxLMRH9uAng3x3MQZh3uBFi1oe+SI430FX6/wcHoIdO3KsvtSaBbRDJEhkcg15uLfS6UrPjmgZxh/IimJ+ifp9UDNmuIe+9IlqpEHgPffB6pVu3uf556zBvXvvQfMnCnuHFwhPJxaxAHSZunPnaMPP73eWk8GkDleYCB9QAkSM39ArwfWraOHXi/1bBgR0Wv1WPfwOqx7eB30Wn5tHcGXAqNEbuWR3F6J2XmgWEDP9fPu4YzDvYAQ0DuToS/NA4pl96WiUqmssns7dfRlKaDXSj0BhvEYQW5frx45qouFxQI8+yw5xnfoAEycWPq+zz1H+z//PJnnPfssEBEh3lxcoXdvql/fvBkYO1aaOQj18y1bAgE22Q6djhYcdu+mOnpvmhiKiVYL9Osn9Sw8Is+Yh9m7ZiPXmIuKgRURXi4cFctVvGtcPrB8mZJjatVa9Gvg36+tL1HApcAwdyHUz5cP5ICeKQVnHO4FBMn9kSN0b2hPom+vZHTYMGDxYnK7/+wzegNmAJDs/ruj32FTwibMxuy7fm6xWDigZxi/wlv182vWAH/8QQHp4sVkhGKPyZOBpUuBY8eAXbuo3l4KevUC3n0X+PtvwGx2PG9vUJLcXuC++yig37NHugWHMsgX+7/A2zvfdrifCipUCKxQYrAfXi4cFQMromI567hKcBU0qdKkTC0CMAyjLATJfYVAJ4I1P6RplabQqrVQQYVmEc0cP4G5G1ck902bUoLp2jXgyhUyyisNe12aBNl9RgbJ7nv2dHXWiqVnDP0tDqUcQkZOBioHVS7y85SsFGQXZCOYA3qG8RO80bLu5k3KugPAq6/Sm7MzdO5MAf2OHdIF9PfdBwQHUw/4o0cpS+5rhAy9IP+3xR+d7gsKgBUraDx6dFHVgZ+w/MhyAEC/+v1QJbgKbuTewPXc67iRd6NwnGvMhQUW+l7eDaeP/Xz75/Fx34+9NXWvUmAqwIpj9NqObj5akfWzYqKAS4Fh7kLpkvtKQZWwethqaNVaxaoQvI4rkvvAQKBhQ/IzOnrUfkBvLyml1QKDBgFLlpDsngP6QqJCo9AsohmOpx3HyuMr0bFWR2TmZxY+jqZSuUMFsw6AgQN6RgGcOQNcuAD06SP1TLyDN1rWTZ8OpKTQMYUaemfo0oXa2u3YId5cXEWno1Xd9etJdu/rgN5oBA4epHFpGXoAOHECuHULKO8HNxcGAzBuHI2HDfO7KOZE2gkcunoIWrUWyx5adtdKtkC+MR838u4E+rk3Sh7bLACkZafh/I3zWHliJT7q8xFU9mSFMsVgMmDcb/TaDmsyjAN6B/j5pcAwJaJ0yT0APNToIamn4N+4IrkHSHZ/8iTJ7h94oPT9HCWlhg2jgH7NGrq/ZNl9Ib1ieuF42nFM2jCp1H3CzAHggJ5RBsOG0Qrh0aNA8+ZSz0Z8xJbc794NfPEFjRcvppVWZ+ncmbbHjgHXrxd1LPUlvXpZA/qpU3177lOngJwc6tPasOHdP69aFYiJARISgL17ra32GK/x3dHvAAAP1n+w1GAeIIO4yJBIRIZEOnXcfGM+wueG42rWVRxLO8a1mQzD+CVKz9AzIuCK5B4gY7yffrLvdH/zJpCeTuN69Urep1s3oFIllt2XwNiWY7H8yHLkGfMQpg+761ExsCKqYB2AbA7oGQVw4QJtd+xQXkCfkQEkJtK4USPPj5efbzW/e+IJyri7QtWqNI9Tp2hhYMAAz+fkDr3I/RM7dwK5uUC5cr47tyC3b9WqdJPC++6jgH7PHg7ovYzJbML3R78HADx6z6OiHluv1aNrdFf8efZPbDy3kQN6hmH8EqXX0DMi4IrkHnDO6V7IzkdFAaGhJe8jyO6XLmXZfTHuqXoPMqZl2N9p7J0FGIUH9OxipHQKCoDbt2n833/SzsUb/PUXOYjec484rvJz5wLx8XSsuXPdO4aQpZdSdt+4MdVs5efTwoIvEQL6kuT2Av5YR++nbE/cjuTbyagQWAH9G/QX/fi9Y2hBZlPCJtGPzTAM4wsKJfecoWdKQ5DcO5uhF5zuT58G8vJK3sdZhenw4bRds4bKGhnnycmhLQf0jF9zw8bYas8e6ebhLdavp60YfZROnQLeeYfGCxa4L5cXsvpSBvQqlTVL7+s8bNs/AAAgAElEQVR+9PYc7gWEOvr//iMnfsZrCHL7EU1HeKXPep965M2x6+Iu5BTkiH58hmEYb1MWaugZD3E1Q1+tGknlTSbyDCoJIUPvKKC3ld1LeW/pbxiNZPwCcEDP+DnXrlnHCQnkfK4UjEbK0AOeB/RmM0ntDQYyLxkxwv1jCQH9oUNk+iYVgpR9kw8zpwaDtV7MXkDfvDk58WdmkmkM4xWyDdn4Jf4XAMCYe8Z45RwNKzVEzbCayDflY+fFnV45B8MwjDcRauhZcs+UiqsBvUrlWHbvbJcmQXYPkOyecY7cXOvYl6WnEsABvdK5fr3o13v3SjMPb7BnD73BhocD997r2bG+/pp6xwcFAZ99Rm/E7lK9OlC3Li0SSCkp79GDtkeOAKmpvjnn0aMU1IeHA3XqlL6fVgu0a0djJSpHZMLaU2uRZchCTMUYdKjZwSvnUKlU6FOXsvQbz230yjkYhmG8iVBDz5J7plRcldwDVtl9acZ4rpg6DxtGW5bdO0+OjWrQFYNrP4QDeqVTPKBXUvAkyO379i3dfM0Zrl61OsHPmgVER3s8NVnU0UdEWFvW/f23b85p23/e0aKIP9XR6/XAqlX00IsvW/cWgtx+zD1jvNpSrndd/62j12v1WDV0FVYNXeWVkgSl4aeXAsPYhSX3jF3MZqvi0tkMPWDN0JcU0FsszmfoAZLdh4eTK/5OVsM5hW39vB+21XUFDuiVTvGAXknGeGLVz7/wAmX6W7UCJk/2fF6APOroAavs3ld19M7UzwsIdfT+sMik1dLq+LBhftMDNuV2CjYn0Ov+yD2PePVcPWJ6QK1S42T6SVy6dcmr5xIbrVqLYU2HYVjTYdCq/eO1lRI/vBQYxiHcto6xy+3bFIAD7gX0R49any+Qnk6LBCoVqTodERBgld2vWuX8HMoyZcQQD+CAXvkINfSC7Ccujgw6/J2kJOD4cUCtpgy9u6xfD6xcScdZskS8O1QhoN+/H8jOFueY7mBrjFf8w8Qb2GboHSGUSZw+XdTrgRGFH4//CLPFjPtq3Id64aX0txWJ8HLhaFuNFnGERQSGYRh/gdvWMXYR5PaBga5Jtxs3JgXp9etAcnLRnwnZ+Vq1nD8mu927Bgf0jGIQMvQdO1KPy+xsCoT9HSE7f9997rvRZ2UBzzxD4xdfpAy9WERH05u00SitpPz+++mD4soV75vPZWdbnVydydBXqgQ0bEhjuStHjEYyolm92m8+RJcfWQ4AeLSFuL3nS6Owjv68f9XRG81GrD6xGqtPrIbR7B+vrZT44aXAMHbJN+Yj35QPgCX3TCm4aognEBgINGpE4+Kye1fq5wVYdu8aHNAzikEI6KtUAdq3p7HcgydnEENu/+ablOmvXRt46y1x5mWLUEcv5ZtuYKB1Ht6W3R8+THVmUVFkDOgM/lJHn59PK+PDh9NY5hxLPYYjqUeg0+gwvOlwn5xTqKP/O+FvmMz+owLKN+Zj+M/DMfzn4cg3yv+1lRo/uxQYxiFC/TwAhOpCJZwJI1uEDL2rAT1QutO9sy3rbLGV3bPbvWM4oGcUgxDQV6pklTj7e0Cfmwts3UpjdwP6/fup1zwAfPEFtVATG7nU0fuqH70gt3cmOy8g1NHLPaD3MwQzvH71+yG8nJsKFhdpX6M9yuvL43rudRxIOeCTczIMw3iKUD8fpg+DRu2BwS6jXIQMvSsO9wKlOd0LGXpnDPFssXW7V0IJrTfhgJ5RDEJAb9vazR9MyOyxbRsF9TVqUD9zVzEagQkTKJs8apRnNfj2EAL6vXuL9sL0NUJAv327d1NqrtTPCwgZ+rg41u+KhMlswopjKwD4Tm4PkLlcjxhqlcjt6xiG8Re4ZR3jEHcl94C4GXoA6N6d7unT0lh27wgO6BnFIJiN2Qb0p0/f7X7vT9jK7d1pQ/HxxyQPr1gR+OgjcedmS716JD83GCiol4rmzYGqVemNzZuLOa443As0bgyUL09zK/5hx7jF1gtbceX2FYSXC8eD9R/06bl7x/hv+zqGYcom3LKOcYgYkvvTp63JHbPZtZZ1tgQEAA89RGOW3duHA3pGMdhm6CtVsq4ExsVJNydPsFiAdetoLMjt9+wBNmxw7vkXLlDtPAB88AH1avcWKpU86ujVaqBnTxp7S3Z/86ZVPuZKhl6tVo5yRCYIcvsRTUdAp9H59NxCHf2eS3sKZawMwzByhlvWMQ7xRHIfGQlUrkxBvGAcfOUKBfcaDZkou4ogu//lF5bd24MDekYx2Ab0gP8HTydOkJGdXk+yI6ORJPMPPgjMmWP/uRYL8NRT9CbatSswdqz35yu3OvpNXsqcCqqJhg3pg8sVuI5eNLIMWVgTvwaAb+X2AnUq1kH98PowWUzYlrjN5+dnGIZxFW5ZxzjEE8m9SnW37F7IzsfEUMbdVXr0oMUFlt3bhwN6RhEUFACZmTSuVIm2QvDkr8Z4QuDYrRsZ2SUkWH/H6dPtB/U//EABrV4PfPmle3J9VxEC+j17SHovFUJAf+CAd3q+//ADbUeOdP25Qh29vy4yyYj1Z9YjuyAb9cLroX319pLMobB9HdfRMwzjB7DknnGIJ5J7wBrQC8Z47rSss4Xd7p2DA3pGEQhvQID1TUjI0O/dS/Iff0MI6Pv3p63QWz0wkLalBfXXrgEvvEDj//3P9Zold2ncmDLWublW0zgpqFYNaNqUVApChwCxSE8HNt4J3h5+2PXnt29PiysXLgBXr4o7N7HQ6YBvvqGHzrcydlcQesA/1PAhqHyxYFUCguzeX+rodRodvhn4Db4Z+I3PSxT8ET+5FBjGaVhyzzjEE8k9cLfTvbv187aw271jOKBnFIEgt69Qgep0ADJICwoCbt0CTp2Sbm7ucOOGVZYt1M8LAf3QocCsWTQuKaifMgXIyKCgdupU38wXkE8dPeA92f3q1fRh0ro1Se5dJSwMaNaMxnLN0gcEUInG2LHuyeN8gMViwabz9NoKQbUUdKvTDQHqACTcSMC56+ckm4ezBGgCMLblWIxtORYBGnm+tnLCDy4FhnEJIUPPknumVDyR3ANFJfcWi+cZesAqu09NBXbtcv84SoYDekYRFK+fBwCt1upC7m+y+40bKXBs0sRqIiIE9E2aAG+8UXJQv3UrsGwZBddLlvg+rSSXOvred4K8zZvpA0UsVlCLNIwe7f4xuI7eY05lnELy7WQEagNxf637JZtHiC4EHWpSGYWwwMAwDCNXuG0d4xBPJfeNG9P9940bwOXL7ress4Xd7h3DAT2jCISAXqifFxBk93IL6HfsAL7/vvRac9t2dQLx8bRt3Ji2xYP6t98GnnySvn76aWvg6EuEgP6ff6Tttd65My1mXLwInBMpc3rhAgXhKhUwYoT7x5F7Hb3RSP9/69dL+xraQQieO9fujHIB5SSdS2Ed/Xn519EbzUasP7Me68+sh9Esz9dWTvjBpcAwLsE19IxDPJXc6/VAo0Y0PngQOH+exp6Wf7LbvX2ENoEc0DN+TUkZekCeTvdr15Jr/ZgxJNtevrzom5PJZG1NJwT0ZrM1oG/SxLqvbVA/YwYFr9WqAe+95/3foySaN6cPgawseiOXiuBga+Asluz+xx9p2707/Y3dRVho2b9fWvPA0sjPJ9+G/v1pLEOEmnWhF7yUCJL/rRe2osBUIPFs7JNvzEf/H/uj/4/9kW+U52srJ/zgUmAYl+AaesYhnkruAavs/o8/yLRarwdq1vRsXj160JxYdl8ynKFnFIHgZl5aQH/ihNUhXkq2baPsrtlM5naJicBjj5GJyK+/kjw8Lo5+n/LlrUHpxYu0+qbTUesPW2yDegBYuJCeKwVqNdCpE43lJLv3FIvFKrcfNcqzY9WvT0qS/Hzg0CHP51bGyDfmY3vidgBAr7q9pJ0MgNioWFQOqowsQxb2XJbRwiHDMEwxuG0dY5eCAiA7m8ZiBPRr19K2Xj26P/QEnY7d7u3BAT2jCErL0EdGUg26xSKt8zpAGdkBAygrO2gQ9dR8/33KaJ88CQweTC7o8+bR/n36WJ2YhPr5hg2pNqk4b7xBb3DLllnf8KRCbsZ4W7fSh5QnHD1Kr4FeDwwZ4tmxVCquo/eAfy/9i5yCHFQNrormEc2lng7UKjV6xdD/GrevYxhGzrDknrGLkJ0HPEsMCU73QrLNk/p5W1h2Xzoc0DOKoLSAHpCH7D4+Hujbl6To3btTL/PQUGDaNOov/8YbJBPft48y9YD9+vmSGDqUsv1SY2uMJ2VrtthYyoTfvk2qB08Qes/36yeO+kHudfQyxtbdXqp2dcXpGdMTALAriWWADMPIF5bcM3YRAvrQ0JKTR84iZOgFxGqfbCu7371bnGMqBQ7oGUVQmikeYM2GSmWMl5RE8u9r18h1f+1aay95gN6cZs2iwP6FF0hWFB4OPPigdR9bh3u5ExtLCw+3bwP/939W+Zav0WjozR/wTHZvNlvr5z1xt7eFM/RuszmBXksp29UVp3319gCAgykHYTJz1oBhGPlhsVi4bR1jH08d7gUiI4GICOvXYmXodTp2uy8NDugZRVBaDT1Q1OlezBZmzpCWRtLvy5cpyP3zT1r5LImICOCjj4DkZKr5r1zZ+jN/Cug1GuD332lxZf9+qjmXSholRj/63buBS5coM2+7yOIJbdvS3yk5mY7NOEV6djoOppDZopAVlwONKjdCcEAwsguyEZ8RL/V0GIZh7iKnIKewuwVL7pkS8dTh3hZBdg+Il6EHWHZfGhzQM4rAnuS+ZUuqfb52TbwWZs6QmQk88ABw5gxQqxYFlbZBemlUrkyrmwIWi38F9AAZoPz+O/3df/8dePllaeYhGOP99x8ZC7qDYIY3ZEhRZYUnBAdbJWmcpXeaLRe2wAILWlRtgciQSMdP8BEatQZtqrUBAOxLltirg2EYpgSE7LxGpUFwQLDEs2FkiRgO9wK2snuxMvQA0LMnze/qVWqRzBAc0DOKwF5Ar9MBrVvT2Feye4sFGD6cWrdVqUKS7xo13DvWlSskX9doxH1T9DYdOlBLPgBYsIAevqZWLfIssFiAr792/fkGg1XW5am7fXHkWkev01GnhIULaSwjhPp5wYROTrSt1hYAsO+KfAN6nUaHhQ8sxMIHFkKnkddrK0dkfCkwjMsI9fNh+jDZ+I8wMkOQ3IuRoRcC+pCQokkqT9HpgIEDabxqlXjH9WcsFg7oGYVgL6AHisrufcGOHcDGjZSh/usvz+RGQna+Xj3/u6scPpyc/AHgxReB337z/RwmTqTtV18BRqNrz924kT7goqKArl3FnZdc6+gDAoBnn6WH0GVBBlgsliKGeHKjbXUK6OOSPTRg9CIBmgA82+5ZPNvuWQRo5PPayhWZXgoM4xZcP884RMwMfZcupGrs3p26+4jJ8OG0Zdk9UVBg/TtwQM/4LUYjcIs+qEo0xQN873Q/ezZtn3gCaNXKs2P5m9y+OFOnUlBtsQAPP+z79oEPPURlDMnJwIYNrj1XkNuPHEkKCTERMvSHDgG5ueIeW4HEZ8Qj+XYyArWBuL/W/VJP5y6EDP3R1KPIN+ZLPBuGYZiiCD3ouX6eKRUxA/patYCUFGDNGs+PVRyW3RdFyM4DHNAzfowgEQJKfxMSsqFHj3rfdf3gQaqX12iAKVM8P56/B/QqFbBoEbXty80l5/vERN+dX68Hxo2j8ZdfOv+827ep/h8Qz93eltq1SYZmNJJ5oFwwmYDt2+kho5XvzefJ3b5z7c4oF1BO4tncTXSFaFQqVwkF5gIcST0i9XRKxGQ2YXvidmxP3M5u/E4g00uBYdyCW9YxDhFTcg/QPbnYyRCgqOye3e6tAb1WWybkZBzQKxVBbl++fOl9M2vUoODJZCIHeW8yZw5tR44E6tTx/HjO9KCXO1ot1Tq1aEH9QwcN8m3HgfHjabthA7URdIa1a2kBokEDz1UWJaFSybOOPi8P6NaNHnl5Us+mkE0Jd+T2MfKT2wOASqUqlN3L1Rgvz5iHbt92Q7dvuyHPKJ/XVq7I9FJgGLdgyT3jEDEz9N7G1u3ebJZ2LlJThurnAQ7olYuj+nkBIbi+fNl7czl7Fvj5Zxq/8ornx7NYrAsQ/pqhFwgNBdato5XVw4eBCxd8d+4GDeiu3Gx23hzvhx9oO3q0+PVfAnKto5cZ+cZ8bE/cDgDoVVd+hngC/mCMxzBM2YQl94xD/Cmg79WLEnkpKZ7J7rOzgRdeIL8rf4UDekYRCAF9afXzAoLLvDf7fs+dS0F4//5A8+aeHy89nX4/lQpo2NDz40lNjRpW51Nf19K7Yo539ix1JgDEd7e3xTZD70vFgp/x76V/kVOQg6rBVdE8QoTryktwQM8wjFxhyT3jELEl995ELNn9vHnUhWnwYGuJq78hBPTl5FeO6A04oFcqzmboa9akrbcy9MnJwLff0nj6dHGOKcjt69RRzspbWwp6fB7QDxpE5niXL9tfiS0oAB55hMoz+vSh7gLeolUrqndKSwMSErx3Hj/H1t1ezu2WBMl9fHo8bufflng2DMMwVgTJPQf0TKn4U4YesMruf/7ZPdn9rVvWlsq5uVQq648mxZyhZxTBtWu0dRTQeztD/9FHFAx26mTNvHqKsFroz/XzxWnThra+Duj1emDsWBrbM8d75x0gLo4+0JYs8e6cAgOB1q1pLKc6eplRWD8vw3Z1tkSGRKJGWA1YYMHBlINST4dhGKYQrqFnHCJk6P0loPdUdr9wIS1i1K8PREQAx45RZyZ/gwN6RhHIIUN//TrwxRc0Fis7D/i/w31JCBn6Awd8bx09YQJt//yz5IWdPXsooAfo9RT+Z7wJ19HbJT07HYdSDgEAesb0lHg2jmHZPcMwcoRr6Bm7WCzWDL0/SO4BStS4K7u/fRv48EMaz5wJLF9O40WLyBTZn+CAnlEEzgb03szQL1pExhotWlB7NrFQYkDfuDEQHEx/r9OnfXvuBg2Arl1LNse7fZuk9mYzbUeM8M2c5Oh0LyO2XNgCCyxoUbUFIkMipZ6OQzigZxhGjnANPWOX3FxSmQL+k6EH3He7//xzih8aNKD7vT59rK2mH3/cu35bYsMBPaMInDXFE7KtV66ImxnOzrbW4Lz6qriO6EINvZICeo3G2gbO17J7wGqOt3Rp0f+D55+nOvbatUmG5SuEDP3Ro7SoIDUBAWTuOHeuLPqZCvXzvWLk625vS7vq7QDIs3VdgCYAc3vOxdyecxGgkf61lTsyuxQYxiNYcs/YRZDbazRASIi0c3GFXr2AsDC6t3dW6ZidDcyfT+PXX6ffGQDefZfKQm/coA5HjgyU5UJKCm0dJTYVAgf0SsXZGvrISLpojUbqhS4WX31Fc4iJAYYOFe+4N25YL9JGjcQ7rhyQyhgPICfTSpWKmuP98gvwzTe0GPPdd1ST5SuqVwdq1aKVZSn+HsXR6aiGbOpUGkuIxWIpYojnD7SuRp4IF25eQEZOhsSzKYpOo8PUjlMxteNU6DTSvrb+gIwuBYbxGJbcM3axNcSTsfnsXbgju1+8mLpIxcQU7WSk0wE//kgLGrt2WUsw5Y5S2ls7CQf0SsVZyb1GA1SrRmOx6ugNBusq37RpgFYrznEBa3a+Rg1afVQSUgb0xc3xrlyxZu1ffZVMDX0N19GXyMn0k0i+nYxAbSDur3W/1NNxigqBFdCgUgMAwP4r+yWeDcMwDMGSe8Yu/uZwb4srbve5uSS7AoDXXrv7vr1ePasn1qxZwM6d4s7VGwgBfdOm0s7DR3BAr1ScDegB8evof/iBjhUZCTz2mDjHFFBi/byA4HR/+DAtivgawRxv/XpSVVy/TmUAM2f6fi6AvOroTSZaaNm3z/emhcWYsX0GAKB7ne4oF+A//VUL6+hlJrs3mU3Yl7wP+5L3wWSW9rX1B2R0KTCMR5gtZmTmZwLgDD1TCv7mcG9L795W2b2j+6ilS4GrV6m8csyYkvcZPZru6c1mGgtKYDliMgGnTtGYA3rGr3EloBfq6MUI6M1m4P33afzii9SCTEyUWD8vULcuuagaDNQmxNc0bAh06UKv4Z49QLlywIoV0ulqhQz9nj3u9VIVk7w8oF07euTlSTaNdWfW4Zf4X6BRafBe9/ckm4c7CAF93JU4iWdSlDxjHtotbYd2S9shzyjda+svyORSYBiPyTJkwQILAK6hZ0rB3xzubbGV3S9eXPp9VH6+9b791Vft3/MtXEjt7C5fBp54groAyJGEBPqACgwE6tSRejY+gQN6JWIyWd+EHJniAdYMvRiS+99+o1Wx8uWBp57y/HjFUWIPegGVSrp+9AJPPmkdz58vrU9By5a0qHDjBnDmjHTzkAnZhmw8++ezAIAX730RLSJbSDwj12hb3Zqht8j1JoBhmDKDUD+v0+gQqBU5+cAoA3+W3APWWvjlyylJcuDA3ft88w2QnEzeRePG2T9eSAjw00/kiPrbb8Bnn4k/ZzEQ5PaNG1vN/RQOB/RKRJAIAc6tKoqVobdYgDlzaPzss96pcVey5B6w1tHvl6jOePBgYNAg4JlngKeflmYOAgEB1gUOrqPHWzveQtKtJNQqXwszu86Uejou0zKyJTQqDVKzU3E5UyS/DoZhGDfh+nnGIf4suQeoZfSnnwKhoUBcHN1jPvOM9fcyGIDZs2n86quU1XdEq1bWevuXX6ZuRHJDCOibNZN2Hj6EA3olIsjtw8KcM6QTK0O/bRu9YQQGUrszscnKApKSaKzEDD0grTEeQG/ma9YAixbJw9FVTnX0EnLk6hF8uOdDAMCiBxchWBcs8YxcJyggCM0i6MOV+9EzDCM13LKOcYg/S+4FJk0CTp+mbL3FQr3mGzYEli0Dvv2W7qsjI0lC7yzPPw/060dy/ZEjqeWdnDh+nLZlpH4e4IBembhSPw+Il6EXVvnGjwciItw7hj0prmBwUbWqc6UE/ogQ0J84AeTkSDsXOcBO9zBbzHhq/VMwWUwY0ngI+jfoL/WU3EauxngMw5Q9uGUd4xB/l9wLREWRJ9LWrZQQS08neb1QGjttGpU4OotKRVL9qCjytnrhBe/M213KmMM9wAG9MhECemeDXiFDf+WK+7bF+/cDf/9NtSovv+zeMQYOpIvv6tWSf67k+nmB6tXpDdJkAg4dkno20iME9CdPWj9YyxiLDyzGf5f/Q6guFAv6LpB6Oh5RWEfPGXqGYSSGJfeMQ/xdcl+cbt2ok9LcuUBwMBnlRUQU9U9ylipVgO+/p+B+6VJg5Urx5+sORiMpEgAO6Bk/R2gl4WyGPjKSpPkmU+nBtCOE2vlRo4DoaNefn5gI/P47rfSNHl3ywoLM6+ctFmDJEvII8aidk9TGeHIiIoLc/wHgv/+knYsEXM26ilf/fhUA8G73d1E9rLrEM/IMIUO//8p+mC0Sdy5gGKZMI0juOUPPlIoSJPfF0emAqVNJ9fr668AvvwBBQe4dq3t3YPp0Gk+cCFy4IN483eXcOfIGCAqiNnxlBA7olYirknuNBqhWjcbu1NGfPk111wDwyiuuPx8Atmyxjrdutcr3bZF5QP/55/R+9uyz1P4zNdXNA0ldRy835FBHHxAAzJhBj4AAn532xY0v4lb+LbSp1gbPtH3GZ+f1Fs0imiFQG4hb+bdw7vo5qacDAAjQBGBGlxmY0WUGAjS+e239FYkuBYYRHSFDX0GvkOwrIz5KkdyXRI0awDvvAPff79lxZs4kNWVmJiX1CgpEmZ7bCHL7Jk0AddkJc8vOb1qWcDWgB6yye3fq6OfOpfT0gAHuy1uEgD42lrYzZgA7dhTdR8Y96Ldvt/oAarW0JhEbC+zc6fwxCu0DOKAvihzq6HU6+tCaOdN+j1YR2XhuI346/hPUKjW+7P8lNGr/b70SoAlAy8iWAORTR6/T6DCz60zM7DoTOo1vXlt/RoJLgWG8AtfQMw4RJPdKytCLTUAA8MMP1K76v//o/l1KnKmfT0ujJFFmpm/m5AM4oFci7gT0gjGeqxn6y5eB776j8auvuvZcAYvFGtB/9BHw2GNU1zNqFBl3AEBuLpCQQGOZ1dAnJgLDhlHZzqhRwJEjtOaQkkLlSnPm0K9TEmfPklqpRg1qux4fD6vk/uzZMls3XgQhQ793r4e1DP5DbkEunvmTMvKT201Gq6hWEs9IPNpVaweA6+gZhpGWQsk919AzpaHkDL2YREdTHT1AN722qltf40zLug0b6N5ywADfzMkHcECvRFw1xQPcz9B/+CHJa7p0sWZSXeX4cVotCwoC7r2XWqY1akQmfUJwf+YMbStWJJd7mZCdTV5+GRnUmnPpUgrm4+KARx6hKU+fTvsIL0tODq2BdO0KNGhA733JydTKs107YPW2ykCdOrTzgQOS/W6yoVkzICQEuH3b+kbta8xmOveJE6WvzojIt0e+RcKNBFQPrY63u73t9fP5ErkZ45ktZpxIO4ETaSe4rt8JfHwpMIzX4LZ1jF3MZuAW/Y9wQO8EQ4dS3anFQjX6UuFMyzrhXrJ5c+/Px0dwQK9EXDXFA9zL0F+7BixeTGPBFMMd/v6btp06UR/04GBg1SrqZ79hA/DBB0Xr5+XQHx30njV2LAXiERHA2rXWrh/BwcDy5fTn0euBdetIgj9xIpnYP/ooVRSoVEDfvtRNpGtXICsLGD4cOBTAsvtCNBqgfXsaS1VHn5tLCwvNmtHYyyw9SCvdL9/3MkL1oV4/ny8RjPEOpRyC0WyUeDakhmj2eTM0+7wZcgu8/9r6Oz6+FBjGaxS63LPknimJzExrLSQH9M7x3nskwT90yBpY+xKDgRKAgP2AXpibvSy+n8EBvRLxVQ39woWUoo6NJRc4dxGkOT17Wr/XvDnwySc0nj6domNAVvXz770H/PwzvXetWWNdExFQqYAJEygGrVsXSEoiF/zMTFInvf02cPEirVmMGgVs3kytQAHghzMku8/dxQE9AHnU0fuIQymHcCDlAHQaHca0GCP1dM5lDCEAACAASURBVESnfqX6CNOHIdeYixNpEikuGIYp8xTW0LPknimJjAzaBgbSg3FMpUpAv340FspxfcnZs1T/Ghp69025LRzQM36BL2ros7KsAferr7qfNS8osJrf9ehR9GfjxwMjR1Ld9F9/0fdkUj//++/AG2/QeNEioGPH0veNjSXl/MSJJMP/+2/g/Hngf/8r+n6j1QLvv0+LAyfKURbz+l/7XDLWUyxycLr3EUJ2flCjQagcVFni2YiPWqVGm2q0YBWXHCfxbBiGKatw2zrmLjIygGXLgEGDgBYt6Huu3EszJEEFqEe9r32PbB3uS4tLbt2yJi8V1KeeA3ol4kmG/soV5y7ApUvpPPXqAUOGuD5Hgbg4WhyoVMn65imgUgFffknnECiWoc835mPO7jl4d+e7Pqt/PXmSAnOAWtRNmAAYzUZsPLcRT/z2BF7a+BKyDdlFnlO+PP0q331H6xb2OmkMGgQs2N0aZqhQ3XwJI7ulFq6dlFnuvZe2Z89ajRIVSE5BDlYcWwEAGN9qvMSz8R6C7J4DeoZhpKKwbR3X0Jdtzp8nP6jOncmjadw4qqHMyaGsy9vK8rHxOg8+SH5XV64A27b59tzOONwL+1SvrqhSCq3UE2BExmSyunK6YopXtSqliI1GsmcXAvySMBiorh0gjbjGg3ZaQv189+4lR7lhYcDKlSS5NpmAe+4p/NGhlEN4dO2jOJ5G0pkqwVUwsfVE9+figFOngG++Ab7+mvzZOnexYMTL/+G5P3/AyhMrkZ5jDTQ3nd+E1cNWo3EV9xQF9VuFwtywEXA6Hq3M+/D88/2h1QLP+H8rcveoWJHUGfHx1Bbl//5P6hl5hZ9P/oxb+bdQp0IddK/TXerpeI1OtTrh/X/ex6aETbBYLFDJxBeDYZiyA0vuyyhmM7B/P/Dbb/QobrbbsiU5GQ8cSGP+fHINvZ7UtZ9/TuWytuW03saZgF6BcnuAM/TK4+ZNq4mHK30zNRqgWjUaO5Ldf/897SO4u3lCSfXzxWnVCvjnH2DTJiAqCkazEbN2zEK7pe1wPO04ArVU2zR181QkZyZ7Np9i3LpFmfX77qN4cu5cIAPxCB/2OhIHxKDz8g5YuG8h0nPSUTmoMia0moDIkEicSD+Btkva4vuj37t9bnV7ymK+3Inq6CdNIq/AMksZqKNfcnAJAOCJ2CegVin37blbnW4I1AYi6VYSTqRzHT3DML7FaDYiu4CUdCy5LwPk51Pp5tNPU9a9fXsyQjpxgu5/u3cHFiwALlwgQ7eZM6lekoN59xhzx/9nzRry2vIVzrSs44Ce8QsEuX1oKLm1uYJQ0G3PGM9koqgWAF56iVbi3CUri7KtwN3188Vp0wbo3h3x6fHo8FUHvLn9TRjNRgxpPASJzyeiffX2yMzPxDN/PgOLsKDhJmYzGdSNHg1ERgJPPQX8tz8XqpbfIfzlTsCkJrje9D0k3U5EiC4EY+4Zgw2jN+DKS1ew+P8W49CTh9AtuhuyC7Ix5tcxmPjHRPfcs9tSQN81dD+efprWaYQa/DKJwuvoT2Wcwu6k3VCr1BgXO07q6XiVoIAgdIvuBgBYf2a9xLNhGKaskZmfWTjmDL1CuXGDWggNHw5UqQI88ADwxRckBQ8JAYYNowRVejollyZPJsdixnPuvZfKZbOzgV9/9c058/OpLBNwTnKvsICeJfdKw536eQFBZm8vQ792LXD6NNWdPPmk6+ewZdcuMsWrXRuIibG7q9lixoL/FuC1ra8hz5iHCoEVsPCBhRjVfBRUKhW+GvAVYr+Mxe+nf8fqk6sxvOlwl6dz/jx5oXz7rc2aRpWTCB+8GLkNliMXN3AdgEalQb8G/TC6+Wj0b9AfQQFBRY4TGRKJzWM24+0db2PWzllYcnAJ4pLjsHrYatSvVN/5Cd0J6FX79uHT3yzIyFBh9Wqqsd+2jdY4yhRChj4ujv5v7C1YWSzirqwHBABTpljHXkAww+tXvx+qhVbzyjnkRL/6/bDh3AasP7ser9z/imTzCNAEYMp9UwrHjH18cCkwjNcR6ueDAoL4ulcSSUlWKf2OHVRGKhAVBQwYQFL67t09S0gx9lGpKEs/YwbJ7gXjKW9y+jQlHcuXtyqOS0KhGXoO6JWGENC7Uj8v4ChDb7EAc+bQeNIkUgF4gq3c3kHwNXrNaPx0/CcAQJ+6ffDVgK9QPax64c+bRjTF651ex8wdMzHpz0noUacHKgU5/htkZQGrV1MgX+gmr81F0L0/I6z7YlzV7cadvyhql6+NCa0m4PHYxxEVGmX3uBq1Bm91ewv317ofo9eMxpHUI2i9uDW+GfgNhjRx0kSwRQvyNUhPhyY5Cd99VxvXr9Of7YEHqAqhQQPnDqUIGjWihaSbN4GjR4HWrUve7/x5+rB+8EGq4RIDnQ6YN0+cY5WAwWTAt0e+BQBMaDXBa+eRE/0a9MOkDZPw76V/cSP3BiqWc6FESER0Gh3m9fbea6s0vHwpMIxP4Pp5hWEwAH373m3C1qQJ8NBDFMS3aWPfkZgRl0ceoYB+yxYgOZlM6LyJbf18aTFFWho9VCrZdM0SC/7PVhrXrtHWGxn6LVvISKRcOZImeYqgHXcgt8/IySgM5j/v9zk2jN5QGMybzbQI2L49UP7YdDSu1BTpOel4ceOLpR7PYqGF23HjSFL/+ON3gvkq8ag98UUEv1kdOX0fxVXdbmhUGgxqNAgbRm/A+cnn8Xrn1x0G87b0qtsLh586jE61OuG24TZG/jLS+d7bgYFA8+Y03rcPej0pl1q3ps4qvXuTcqzMoFZb3e5Lq6O3WGixKSkJ+OUX383NQ3479RsycjJQLbQaHqj/gNTT8QnRFaLRtEpTmCwmbDy/UerpMAxThuCWdQojLo6CeZUK6NQJmD+f5NcnTgDvvgu0a8fBvK+JiQHuv59u1H/4wfvnc8XhPiYGCA72/px8CP93Kw1PJPeOMvSzZ9N2/HiqR/KE9HTgyBEad7fv5r3/yn4AQINKDfBUm6eKOGL/+COVQMXFAS9O1iHho68AiwrfHf0OG87+VeQ4SUnArFlU1tO1K2Xls/PzULXX94h+qzPwbBNcrPYxss03UKt8LczqNgtJLyZhzYg16FuvLzRq99z8q4VWw9bHtqJ/g/4wmo2YtGGS83X+d2T32EfGeKGhwJ9/AvXrAxcvAn36UJlYmcFRHf2vv5LxDUD/YwUF4pzXbAYSE+lhFr894tJDJLcf13IctOqyI5zqV78fAGD9Wenq6M0WMxJvJiLxZqLPWl/6M16+FBjGJ3DLOoVx9Cht+/WjDM3LLxdtecxIg2COt3y51bDbW7jicK+g/vMCHNArDW/V0MfFAVu3kgRcKKD0hK1badu8ObXMs4PQq7pd9XZFvp+dDbxyp/R20CC6PvMT2gP/PQ8AGLj0SXy06DZWrAB69SKvkzffBBISgKBa8Wj68osIe6s6UjuOQaJlFzQqDQY2HIg/R/2JhMkJeKPzG6LVMmvVWnz6wKcopy2H7YnbCxUHDikW0ANARESh4T+OH6cObjk5okxT/thzus/OBl54oej30tLEOW9uLlCnDj1y3TA4tEPizURsPr8ZAPB47OOiHlvu9GtAAf2GsxtgMpskmUNuQS7qLKiDOgvquGdeWcbw4qXAMD6DJfcKQwjobVobMzJg2DDyKjh+3JrE8xZluGUdwAG98hAjQ3/lSlEjEcBaOz96NFCrlvvzE3CmXd0dhIC+bbW2Rb4/bx6V5dSuTWqeY8eA3buBkVXfAW5GoyAoCS+tf73QGd6iyUPjESvQcE4X5DzeBCdCP0ZmwXXUKl8Lb3d9GxdfuIi1I9figfoPuJ2Nt0d0hWi83ul1AMDLm14u4rJbKkJAv38/1YgJx4oGNm6kkvJ//gFGjBAvGS1rBNncxYt31xvMmkXqkuhoq4IkJcXnU3SVrw99DQss6BnTEzEV7ZtDKo0ONTugQmAFXMu9VnidM4wvOHf9HBYfWIzrudcd78woDpbcKwwO6OVJxYqUdQKA777z3nlyc8k/CSiTLesADuiVhyemeFWrUgbebAauXrV+Pz7e2nZi2jTP5wg4XT9vsVhKzNBfumTtnjdvHpWbq1RAx47Aj98G45fHqJ832i1EVO8VuHfGS6jwdnXEN34Ep/N2Qq1SY2DDgVg/aj0SJifgf13+V8Rkz1tM6TAF9cLrISUrBTO3z3T8hKZNKRV/+za5ttrQvDnwxx/0u69bB0yY4H1Fk+SEhVnfiG1l9ydPAh98QONPPrEuOsk8oDeajfj60NcAgPGx4yWeje/RqrXoU7cPAGDdmXUSz4YpK6w+sRqxX8biyXVPos6COnhr+1uFEmymbFAoudez5N7vMZspowNwQC9HBNn9Dz/cnSwUi1On6P8gPLx01a/FotiWdQAH9MrDE1M8tdrqQmlbRy9Ezg89RI6hnpKQAFy4QIsHnTvb3TXpVhLSc9KhVWvRMrJl4fdffZUW5Dp1AoYOvft5g1v2xLiW4wCVBSkdHsF/qo9w03AdNcNq4q2ubyHphSSsHbkWD9Z/0CvZ+NLQa/X49IFPAQCf7P0Ex1KP2X+CVkvufQCwZMldP77/fmDVKkCjoXZ7r0jX/ct3FK+jt1iAZ5+lD4oBA2g1OOqOcaHMA/qN5zYi+XYyKpWrhIcaPST1dCRBDnX0TNnAaDZiyqYpGP7zcGQZslAhsAIy8zMxc8dM1FlQB7N3zUaWIUvqaTI+gDP0CiIxkVoW6fVkMMTIi759gcqVKVEoJPPExhmH++Rk4NYtuq9u2NA785AQDuiVhieSe8Aquxfq6JOSyHUOoChaDAS5ffv2DlvfCdn5FlVbIFAbCIDiuB9+oGv2449Lv3Y/6P0BapWvBbVKjQENB2Ddw+tw4fkLeLPLmz7JxpdG33p9MbjxYJgsJjz757OODfLG38ncbt5MiyHF+L//A5aSpxrmzSNzV0VTvI7+xx+B7dup+8KCBfQ9PwnolxykRZpHWzwKvbZs9sTtW68vVFDhSOoRXM4spcMGw3hIalYqei7viQ/2kJJnWodpSJ2SipVDV6Jx5ca4kXcDr219DTELYvDBvx8gp6CsGJOUTbiGXkEIcvumTSlYY+SFTgeMHEljb8nuXamfb9CA5qQwOKBXGp4G9IIxnpCh//BDynx260YBuBh4UD9vNlt9z8aNA1q1Kv25FctVxLGnjyFtShp+G/kb+jXo59NsvD0+6vMRymnLYVfSLqw4tsL+znXqkKsfAHz1VYm7jB1rFVJMnUrZesUiZOgPHCDTu5deoq9ff53q5wHqRwgULR2RGSm3Uwpl5uNblT25vUCV4CpoX4PeW/48+6fEs2GUyJ5Le9BqcSvsuLgDIboQ/DzsZ7zf633oNDoMbzocx54+hu8GfYd64fWQnpOOKZunoO4ndfHJ3k+QZ8yTevqMF+AMvYIQzNZYbi9fHn2Utr/+SiWkYlPGDfEADuiVhyc19EDRDH1GhlXmPX2653MDKCIXAnoH9fMAsO8KubsL9fM//ECG+yEhwDvvOD5dmD4MlYLc/Ft4kVrla+F/nf8HAJiyaYrj+s2JE2n7zTelut9NnWptQPDEE1RXr0jq1iX5lsEADBkCpKbSiqtt9wU/yNAvO7wMJosJHWp2QJMqIpSy+DEsu2e8gcViwaK4ReiyrAuu3L6CxpUbY9+EfRjSZEiR/TRqDR655xHEPxuPrwZ8hdrla+Nq1lU8/9fzqP9pfXyx/wsYTIZSzsL4I9y2TkGwIZ78adOGZO65ucAvv4h//DLesg7ggF5ZmEzWpuRiZOg/+YT6obVq5VQ23SmOHaOFguBghxl/k9lU2IO+XfV2yM62qv5fe80as/krL933EhpUaoDU7FTM2D7D/s4DBpBze0oKsL70oOf994HHHqN/hWHDyAFfcahU1iz97t20XbiQ6ucExA7otVrgmWfoIYKkz2wx46tDpLYoi2Z4xREC+r8T/vZ5RlSr1uKZNs/gmTbPQKtmuaYjRL4UvMbFmxcxaOUgTNowCQXmAgxrMgx7x+9Fo8qNSn2OVq3F47GP48xzZ/B5v89RPbQ6LmdextPrn0bDhQ3x9aGvYTR7ydTJD9h0fhPe3fmuIv4GLLlXEBzQyx+VypqlF1t2n5NDvlwAZ+gZhXDrltXmvGJF944hZOj37AHefZfG06eXXqjuKkJ2vnNnhzUs8RnxyC7IRnBAMBpVboS5c8nTIjoaePFFcaYjJbYGeZ/GfYojV+306NTpSFcPlGiOJ6BW04/79QPy8oD+/a3vYVJy6BDZMYiGUEcPAMOHW0sSBMQO6PV6YNEieug9r3Xfnrgd52+cR6guFMObDhdhgv5Ny8iWqBZaDTkFOdiRuMOn59Zr9VjUbxEW9VtUZn0MXEHkS0F0DCYDZu+ajcaLGuO3079Bo9Lgg94fYOXQlQjV2/dsEdBpdHiqzVM4N/kcFvRdgKrBVZF4MxFP/P4EGi9qjO+Pfg+T2eTl30R+PLnuSbyx7Q38dPwnqafiMSy5VwhZWdZ2ZRzQy5vRo2m7bVtR421PiY+n2KdyZSAiouR9zGbqhgRwQM/4AYLcPiTEfcMH4Q4tOZkugPHjgcGDxZkfYHW4dCLjvy+Z5PZtqrVB8mXNXW3qlEDvur0xtMlQmC1mPLfhOfsGeYI53oYNdqPjgAByvu/QAbh5E+jTh0xgpWL3bqB1a3LkN4ilWhW6I4SEkM9DcYSA/upVWfbyW3qQXAxHNR+FYF2wxLORHpVKxbJ7xmO2JGzBPZ/fg9e2voZcYy461+6Mw08dxkv3vQSVG4vSgdpATG4/GQnPJ2Ber3moHFQZ566fw5hfx6D5582x6sQqmC1mL/wm8iMzPxOJNxMBWM08/RmW3CuEEyfoMz4yklSMjHypXRvo0oVerxUOvKNcwZnM+4ULJPfX66lsU4FwQK8kPDXE27TJKokBgGXLKN2rFunf5PPPgb/+onHxjGoJ2Pafnz6dMs6dO1PZtJL4sPeH0Gv02JW0CwdSDpS+Y4MGQNeu9Gb49dd2jxkURDX0zZoBV64AvXuTf5yvMZmA556jKV+6BKxZI9KBO3Sgv8GmTdZWi7YIfUgLCqzXhSdYLEB6Oj08XCC4lnMNv8RTDdmEVhM8n5tCsA3oHXZ+EBGLxYL07HSkZ6f79Lz+ioiXgmgkZyZj5M8j0fO7njh97TQigiOw/KHl2P7YdjSL8DwbExQQhCkdpiBhcgLe7f4uKgZWRHxGPEb8PAKxX8Zi7am1iv/fOZVxqnC88+LOIl/7I4UZepbc+zcst/cvhBhj+XLxPkBcqZ9v0oT6PCsQDuiVhLuGeEYjFaX36UN97IVMRvfu4szLYgHee4+KLi0WYPJkoHlzh0+Lu0IBfd1y7fDjj/S9jz4ST/0vF2qWr4nBjUkF8dXBkl3sCxHM8b76iqJlO1SsSOsntWsDZ88CDz7oHXNRe3z1FXD4sPXrhQtFPPi4cUWl97bo9daFLTFk9zk5JOWKiKCxB3x/9HsYTAa0jGyJVlF22jSUMXrE9IBOo0PCjYT/Z++8w5o62zh8J2HJUtwDFfcWxb2q1lkHWveoq2qr1mrrZ612OWpbrava1l3EPXCvuuuoWhdO3Iq4ERRF9sj5/ng5CchKQgIEcl9Xrgzec84LJDnneZ/f83u49fJWph03IjaCwrMLU3h2YUurMh0w4kch43OJjWDGvzOo/GdlNvptRKlQMrreaG6NvsUA9wEGZeXTwsnWiW+afYP/WH+mNJ+Cs60zVwKv8OHGD6m3rB577+zNsYH99aDrSZ4vu2C+WfrouGiNV4dFcm/mWAJ686JHDyGxvXEDfH2Ns0+Lwz1gYEB/+PBhvvnmG4YNG8bHH3+c5GYhC3n5Utzrk6F/9EhkfX/5RTwfMQJKldL+LKNIEkyYIFqKAXz3nWgenw5RcVFcCRRf1P7/1kOSoFmztNvUmTNy27J119alHVR8+KH4/z5+rFU7pEGJEiKJXbCg6PL24YcQHW2sWadNSIj23/7118JA6+RJUU+fKWRDp3tJkjRy1eEew40ecJgzjjaOtHBrAcCe2xbZvYXUiY2PZemFpVT4vQKTDk8iLCaMBiUacG74OX7v8LvJZdR57fIyucVk/Mf6M6npJBysHbjw7AId13WkuXfz9LuWmCFyQF+xQEUAVl5eSXRcJp1MjIycnQdwstHNV8FCNsUS0JsXzs7Qtat4vGqVcfZpCegBAwL6qVOn0rZtWw4fPkxwcDAhISFJbhayEH0l9/HxQot98qT4kG3cKGTxiVvXZYT4eBg+HGbPFs/nzIEff9QpxX7p+SXi1HEUdijMztVigWHQoIxNJzsTp46jmGMxQqND2XI9jZYednZayVIa5niJqVhRlN07OgpPwgED0k3uG4WpU0VDg6pVxb+9Rw/x+p9/mv7YQLYM6M88OYNfkB95rPLQr0a/rJ5OtsNSR28hLSRJwsfPh+qLqvPp7k95+vYppfOWZlXXVZwaeirTFS/58+Tn51Y/4z/Wn/GNxpPHKg8nHp5g6YWlmTqPzEAO6D+v/zmuzq68jHzJtpvbsnhWhiEvuDjbOqNS5kz5ba5AkiwBvTkyYIC4X78+1TbMOhMWBgEB4nEublkHBgT0ixcvxtvbmzNnzrB9+3a2bduW5GYhC9E3oN+yBW7eFON9fYVbOGgD+oxk6KOjoXdvoblWKsX9uHE6by7Xz1d0qM+N6wrs7LQBYVbyKvIVHdd15L0V77Hj5g6jGCJtvr6ZdmvaERwRDMDyi8vT3mB4Qt317t2iQF4H6taFbduEYZ6Pj6h6MKUy9Pp1rbx+/nxx3NGjxfO1a41T1p4uiY3xsgmyTLVntZ4WM6YUkAP6Ew9P5MgspwXDOXz/MPWX16fX5l7cfnmbgvYF+a3dbxp5vVKRdRWEhRwKMavtLOa0nQPA5hubs2wupkIO6GsUrsHQ2kMBzHbhwlI/n0N4/Fg4/1pZQeXU21FayGa0bStqtoKChIQ0I8jO9UWKpF5uHBMjYh2wZOgTExMTQ2O5B7SF7IU+Ab0kiablIFzLErs+yr3oDc3Qh4eLvulbtgi3fR8f0LMcQw7oYx/UA4RUPG8Wn3ufvn3KeyveY++dvZx4eIKuG7tSa3EtNlzbYHALo0vPLzFou5AexKpjUaDgeMBx7ry8k/pGVatCkyYizb5ihc7Hat0a1qwRAomFC2H6dIOmnC6SBF98IabXtau2oUHjxlCrljA3TMfTzzgULSrus0mGPjQ6lA1+ot2Tpfd8ypTLX45KBSoRp47jwL0Mnugt5Bh+PfkrrVe35vzT8zjaODK5+WTuj7nP2IZjs1WrwQ+rfIgCBWefnOXhG2P26cxawmPCNQ73VQtV5ePaH6NUKPnnwT9pn6uyKZoe9Jb6efNGzs5Xrpw9e2haSBkrK+iXoFDMqOx+c8LiaVqB+p07wivM0VFbUpwD0TugHzZsGOvWrTPFXCxkFLmGXhdTvMOHRVY+Tx5t6lQmIxn6kBDhYH/gADg4iCyyAW3vzj0VLeuuH6wPJDXfzwruvrpLE68m+AX5UdypOOMajsPJxomrL67Sd0tfqi6sivclb2LjdZcPBYYF4rnek4jYCFQKIfsrk68MAF4X04l4ZXO85ctFe0Ed6dVLmzmfPDmpYZ2x2LkTDh4U59c5c7SvKxTat9rChZkg+89mkvsN1zYQERtBpQKVaFqqaVZPJ9siZ+n33U3fI8JC7mDvnb0A9K3el3tj7jGlxRSde8pnJkUdi9KsdDMAtt4wVkuPrOfWy1tISBS0L0ghh0KUyluK9uXbA9oWnOaEpWVdDsEitzdfZNn9jh1CZWEIx45pS3o/+yz1cXKNffXqOc9VOxF6B/RRUVHMnTuX5s2b8/nnnzNu3LgkNwtZiD4Zejk7P2yYcExLjKEZ+mfPRI/J06eFxfqhQzq1p3uXkMgQbr+8DcDbm/UoVkyntvUm40rgFZp6NeXB6weUz1+ekx+fZE67OQR8EcC0FtPInyc/t1/eZsiOIVT4vQLLfZenK8WPiY+h+6buPAp9RMUCFZnbTvRSt1JaAcJwKE4dl/oOevQQkoUHD8TfWQ9GjRLVEJIEY8caV3ofFaWtrPjf/6Bs2aQ/79tXvDX8/UVdv0nJZgG9fOE7zGOYxQwvDd4r/R4A55+dz+KZWMgu3A+5D8CYBmMo7FA4i2eTNt2riL6qm6/nHNm9LLevWqiq5rVPPMSi8opLK4iJj8mSeRmKRXKfQ7AE9OZL7dqinj06Wptl14eQEPjoI3EB+/HHQsabGrnAEA8MCOivXLlCrVq1UCqVXLt2jYsXL2pul0yR7rOgO7oG9BcuiCBQpUq5rt2QDL2/v7Chv3pVSJ2PHYOGDXXfPhHnn4oLeYfoshBZgP79hUInKzj16BTNvZsTGB5IzSI1OTHkBG753ABwyePC982/58HYB/za+leKOBQh4E0Aw3cNp+XKlqlKESVJYtSeUZx8dJK8tnnZ2WcnXSp1AeBeyD0K5inIs7Bn/H0njYjX3l58mYHO5niJ+fVXIc44ftyw79LUmDsX7t+H4sVh0qTkP7e3h6Gi/NK4LexSwpgBvZWVcGUcNMigN+Pl55c59/Qc1kprBrpnsdwkmyMbm10Puq5pLWVKrJRWDHIfxCD3QZoFNQupk8GPgt5Ex0XzOFQsLpd1KZvO6KxHbkF68tFJnr7VzeMku6MJ6AtqA/qOFTtSzLEYQRFB7Li5I6umZhAWyX0OwRLQmy8KhTZLv3q1fttKEnz6qUg6li8vjJrSwhLQJyc+Pp6pU6eydetW/vnnn2S3I0eOmGqeFnRB14D+11/FfZ8+4OaW/OdyQP/smW4OlH5+0LQp3LsHZcrAv//q1Gc+NeT6+Yi7Qm6fVe72++7uo/Wq1ryOek2Tkk04NvgYRR2LJhvnZOvEV02+wn+sP3PazsHB2oHjAcepubgmc07NSVZf//vZ3/nr4l8oFUrWd19PHN10HgAAIABJREFUpYKVKJ2vNGXylSFeiqe5W3MA/rqYTk962Rxv+3YIDNTrdytVSrSSAxg/3jj9pJ88gZ9/Fo9//VWUK6XEyJHiu3z/frh9O+PHTRVjmuLZ2oK3t7gZUKsnZ+e7VO6S7TOM+hCvjmf/3f08emOEFpcJuDq7UiBPAeLUcVx7cc1o+00NWytbvLt6493VO1vVY2dXMvhR0JsHrx8gIeFo40gh+0KmP2AGcXV2pZFrIwC23cgZRsEpZeitlFZ8XFt44yz1NS9zPI3k3tYiuTdboqLg1i3x2N09a+diwTD69xcXg8ePC7WprqxcKby5rKxg3brULzZlLAF9clQqFW3btuW1ofUOFkyLHNCnVUN/7542JTthQspjChUStuSSlH528+xZeO894bZerZoI5hMb7L3DoUOwaVPaMm+5fl56VJ/atbPmM7jx2kY813sSGRfJB+U/4MCAA+nW2+WxzsO4RuO4OvIqrcq0IiouivEHx9PYqzF+L0QNz8F7B/ly/5cA/Nr6Vz6o8IFme7kHt4udCwC7b+/meVgawai7O9SvL8w+Vq7U+3f86iuxdvPwobYMKSN8/bXwQ2zcWOt3khJly0JHUSbNwoUZP26qyKZ4b9+KiWURkbGRrLm6BhC953MK8ep4huwYQvu17Skzvwy9fHrx78N/kTJYw6FQKKhdrDYAF59dNMZULZgxsty+rEtZsylV0cjuc4jbfUoBPcDQ2kNRoODQ/UOa/5M5oJHcWzL05suNG8KIp0AB7eK9BfPC1RXef188XrNGt23u3hVG3gDTpkG9emmPj4wU20COblkHBkjuq1evzv375vPFnWtQq0VNCaSdoZ89W4z94IPUZUpKpW519EeOQKtWYiGhfn0hsy9ePMWhMTEwamw4bZb2pPf+JsxaGJTiOEmSOPPkjHjypH6WZOeXnF9C3y19iVXH0rtab7b32Y69tb3O25dxKcPBAQdZ3nk5zrbOnH1yltpLajPh4AR6b+6NWlIzyH0Q4xolLXeQA/qrL67SyLUR8VI8Ky+lE6jL5njLluldDG9vrw3kZ8wQgb2h7Nwp2tEpFLBgQQq+I0ePatuGoDXHW7FCtBE1CU5O4peEjMvuJUksCoSH6/133nJjC6+jXlM6b2lal81CMwgjopbUDNs1jNVXVqNAQbwUj891H5qtaEadpXXwvuSdIbl87aIJAf1z0wf0kiQRHhNOeEx4hhcjcgMZ+CgYROKA3lzoXlUE9McDjvMi/EUWzyZjRMVFcS/kHpA8oC/jUoa25doC5mWOZ6mhzwEkltubyUKfhRSQHa9Xr07/hBIbK0pNw8KEX1dqScnE3Lgh9luggGhtl4PRO6CfPn0648ePZ/fu3Tx79ozQ0NAkNwtZxJs3WrdzF5eUxwQGatucTZwIiPd5ip8hOaBPrY5+xw7o0EF8sFq1Eq75qSgDHj2Cpi0jWPSmE1TbDKVOMfG/QRw/kdw47snbJyIrrVahCqpN376p/cLGR5IkZvw7gxF7RiAhMaLOCNZ2W4uNykbvfSkUCoZ6DOX6qOt0qtiJWHUss07NIiQqhIauDVncaXGybJMc0J9/ep7+NfoD4HXJK+0go3dvITe6e1cEzXrSs6cQWERGaiX4+nLvnvY7eexYqFPnnQEHD0LLltC+vebN1qYNVKgAoaG6L8zqjUJhvDr6iAjxd3Z01Ls+YZmv8DgYWntolvbKNhZqSc3wncPxvuSNSqFiY4+NXBlxheEew7GzsuPi84sM2TGEkvNK8t2R7wiN1v+8kJkBfURsBI6/OOL4iyMRsUaoPcnhZOCjYBByMFnOJXXlV3bDLZ8bdYvXRS2p2X5ze1ZPJ0PcfnkbtaQmn12+FEvOZNWR10Uvvbq8ZCWWGvocgKV+PmfQrZtIvNy+LRS/aTFtGpw5A/nyiQUAlSr9/ecSh3swIKDv0KEDly9fxtPTE1dXV1xcXHBxcSFfvny4pBZIWjA9stzewSH1wsYFC4SjZMOG0KyZJlFfvHgKiXi5jj6lDP2qVdC9u9hX166iNV0qNSwHDkCtehGcK98Zyhwlj9IJldoOqfzfdPxpNk+eJB1/7omQ2/OiOh3a2FM4k8qNJUliwsEJTDosnNy+bfYtCzsuRKXU4QsjDUo4l2Bnn52s7baWgvYFKedSjq29tmJnZZdsbKm8pSjrUpZ4KZ5iTsVwsHbg9svb/Pvw39QP4Oio1bcbYI6nUAg/EYUCNmyAEyf02z4yUhjuv3kDjRppmydoiIvTGi8GBAjHPIQIRO4y8scfJsz0ZbHT/e2XtzkecBylQsmQ2kOyZA7GRC2pGbF7BF6XvFAqlKzttpae1XpSo0gNlnZeyuMvHzOj1QxKOpckOCKYn078xCe7PtH7OLLk/krglWQeFBZyF+aYoYec43afWG6fUsmDZyVPijgUITA8kF23d2X29AzC0rYuB2AJ6HMGjo5ah/q0zPFOnNCaNC1Zoo1R0iOX1M+DAQH9uyZ48s1iipfFpGeIFxoKf/4pHn/9NSgUeHsLY7Lnz2H69HfGp5ahX7BAuNTFx8PgwcKYwi55cKpWw9Sp0K5TJK/adoGyR3CwcuTw4P3MayccKcMafEPboaeIjtZud+Zxwgrdk/qZ1ns+Xh3P8F3DmX1a6M9nt5nN9PenG61eU6FQ0K9GP5797xnXP7tOMafU671alG4BCGPA3tV6AzqY48my+y1bIDhY7/nVqqX11xs7Vr/+8KNHi172hQoJbwSbd8UMf/2l/UIFOHVK83DQILH+5OcnqjVMgjGN8QzgL1/xv/ug/Ae4OrtmyRyMhSRJjN47mmW+y1AqlKz+cDW9q/dOMqaAfQG+bvo198feZ/WH4uS85cYWgsJTLrFJjQr5K+Bg7UBEbISmhaWF3Im5B/RH/I/wMuJlFs/GcFJyuE+MtcqaIbXEYqWsRspKJEliwLYBNPqrEW+j36Y4xiK5zwFYAvqcg3yxv369qM99l5AQ4YivVou4o1cv3fdtCehTp3nz5mneLGQRLxMuGFIzxFu6VKRRK1cGT09CQhJU9zVXQ5uvWL4iFn//ROPfbV0nSSJCHztWPP/iCxGspdC3KDhYqPGnTI+C3l2h3CEcrB3YP2AfjUo2YnSj4XR26wvKeK5X7cOwMS81GdoDfiKgzxNSj86dM/Yn0YXouGh6b+6tcZ3/y/Mv/tf4fyY5lpXSKl35viy7P/rgKMM8hgHgc90nbdlynTqip2dMjP7tPxKYPl20tb94Eby8dNvmr7/EWKVSfA+7vhuvvnkD338vHpcoIe4TBfT58mm7lpishZ1sjJcFGfqY+Bi8L3sDaP6X5ookSXz+9+csOr8IBQq8u3jTr0bqzodWSis+qvkRdYvXJU4dx9qra/U6nkqpwr2ocC72feaboblbMF8kSdIE9OYkuQeoUKAC7kXciZfi2Xlrp0mOcfHZRf44+4dJ+8CnZoiXGPn7bf/d/VwNvGqyuejCrtu7WHNlDf89/o9NfptSHGOR3Js5gYHw4oW4+Kia+vvSgpnQqpVIvrx6BX+/0645NFSUawYECMPtBQv027cloE+d48ePp3mzkEWklaGPjoZ588Tjr74CpZLJkyHodTgKz0+gyWziK/nw44+JtklsiqdWiwB+yhTx2rRpouG4Mvnb58wZ8PCA/YeiUfbtBuUP4GDtwN/9/6ZJqSaAyFiv7bOEEnYVIO8j1rwdzJIlEmpJzbUQ0YO+Y636Jm+JFBYTRqf1ndhyYws2Kht8evpo2vBkFXLLuvNPz1OtUDWqFKxCRGwEG65tSHvDDJjjgciwy//eb7+F9BpZXLyolcxPny6+j5Px888QFASVKmnd9xIF9KDdx/btqds1ZIgslNzvvr2bF+EvKOpYlI4VOmb68Y2FJEl8se8L/jz3JwoUeHXxYoD7AJ22lTN33pe89T5uZtbRW8ievAh/QXhsOAoUlM5XOqunozemdrsfuWckn//9OZ/s+sRkho66BPTl8peja+WuSEj03tyb8Jis6SoSp47j60NaM5gVl1akOM4iuTdz5Ox8hQpa41sL5otKJVrYQdKkVFiYqAs+e1YkK7dtE2bHuhIaqnV7zuEO92BAQN+iRYtkt5YtW2puFrKItAL6tWtFW7nixaF/fy5fTlDflz2EZJXgRF1vIatWwZ07CdvIGfqAABgyRLsqtmCByLq+I0eXJPj9d2jWDB49jcb+4+6oy/2NvbU9e/rtoVnpZknGO9k6sXvQJqywhUq7+WztXLx23iZWGQqxeRjb17QfvpcRL2m9qjWH7gv1wN5+e+lWpZtJj6kLievoTz46ydDaQwFYcmEJaim5iaCGfv3Eie3GDTh50qBjf/aZEHAEBQkpfUBAyuNCQrQWCp06pWKmd/8+/PabeDx7tnDeA7h6VXzJJlC9OrRoIWT+S5YYNO20ycKAXpafDnYfjLXKOtOPbwwkSeJ/B/7HgrPi87/cczmDaw3Wefs+1ftgo7LhcuBlLj2/pNexLQG9BTk7XzJvSYPMSbOaHlV7AKJdqZwVNia3Xoo+3Csvr+TnEz8bff8x8THceSUuCtIK6AGWdFpCcafi3Ai+wWd7PzP6XHTB66IXN4Nv4mLnglKh5OSjk9x5eSfJGEmSLJJ7c8cit895yHLNXbvERWZEhLjAPHVKyDkPHoQaNfTbp2yIV6JE6mbhOQi9A/qQkJAktxcvXrBv3z7q1avHgQMHTDFHC7qQWkCvVmuzo19+iWRjy+jR4mW39ju040qdJL7AVaZOTXguZ+gDA4UJnkol7uX+j4l4+1bEk2PGQKw6hmJjexJRYg95rPKwu+9uTdb5XWoVrcX8DkI5oG45kU+W/w6AXYgHTRoll/Ibi6dvn9Lcuzlnnpwhf578HBl0hFZlU0oxZw1yHf3RB0cZ4D4AOys7fJ/58u3hb1PfyNlZON6DQeZ4ANbW2hh87Vpwc4O6deGXX4QBKYj3zcCB4O8PZcqIt0QKQg0R5cfEQOvWoul88eJih5KUzMlUbmG3dClJ/BSMQhYF9A/fPGT/3f0ADPUYmqnHNhayUeS8/8RndGmnpXorWPLnyU/Xyl0BWHEx5WxZaiTuRW9pJ5c7MUeH+8RUKVSFqoWqEquOZfft3Ubd9+uo10kWCb775zs2Xtto1GPcfXWXOHUcjjaO6XqAFHYozPru61EqlKy8vNIgVU5GCIsJY/LRyQBMaTGFduXaAcnVQZFxkcSp4wCL5N5ssQT0OY+aNcHdXVw3rlkDXboIcyVnZ+GuXbu2/vuUOz/lguw8GBDQ582bN8mtYMGCtGnThpkzZzJBl56AFkxDagH9/v0ia+vsDJ98wrp18O+/kMchnrfFxAWGWz43MbbeItatg+vXERps2eHM1ha2btWuoCXCz0+0oN+wAVQ2MVSf2otnzruws7JjV99dtCyTtmpjZN0RdKvYC1RxSHUXAuBRpL7JukvcfXWXJl5N8Avyo7hTcY4PPk79EvVNczADkf9mRwOOUtihMMs7i/6+M07OYPXlNGrkZdn9pk1ihdMA2rUT9fDNm4tA/cIF+OYboZqvUUM42u/eLd4SW7aksuh54gRs3ix2MHeuVs3RuLG4f0d236WLWD8KChIei0bFWKZ4KpX45Xv00KlVitdFLyQkWrq1pHz+8hk7dhYgSRLfHP5GYxS5qOMihtcZbtC+BrsPBmDt1bV61fpWK1QNK6UVIVEhPHzz0KBj64JKqaJH1R70qNojw10tcgN6fhQyhLka4iXGVG73Aa+FhKqQfSG+bPglAIO2D+LUo1NpbaYX6Tncv8t7pd/jx5aidm/UnlH4vfAz2lzSY+7puTwPe05Zl7KMqDtCU+6z6sqqJJ0y5EUQlUKFg7VDps3PghGxBPQ5EznG+OEHOHRIOODv2wf16um/r/Bwbalxnz7Gm2M2xmhNkYsUKcKtW7eMtTsL+pKaKd7cueJ+2DBCcWb8ePF0wMT/eBkVRD67fCzpJLTOVh6rkazfilpqpVI0C8+fX5hUeHomO+S6dSKYv3kTirvG0uS3PlyL24GtypYdfXbolPVWKBSs6LaMUo7aDEyfZqYJsK8EXqGpV1MevH5A+fzlOfnxSaoVzn4rd81LC0XDhacXCI0OpX/N/kxqKtrpDds1jNOPTqe8YYMGQsMeFSVS7AbSp49Y2Hz2TMjg27YV3ofXrokSJoCFC1NZMFWr4UtxccmwYUklUo0aift3AnorKxgxQjw2ujmebIoXFASxGeiRbGcnVhtS6eqQmHh1PF4XhbOgOZrhSZLE9/98z4yTMwD444M/GFF3hMH7a1OuDcUci/Ey8iV7bu/ReTtbK1uqFxZGNqaU3dtZ2eHT0wefnj4ptpO0kBQ9PgoZJicE9LLsft/dfSm6rvu98KP35t7UWFSDJ6FPkv08NR68fgCIBflZbWbhWcmT6Phoumzoovm7ZRRd6uffZWLTibQt15bIuEh6+vTMlHr6wLBAfj35KwC/tPoFG5UNnSt1xsXOhcehjznsf1gzVq6fz2uX12idbCxkIrGxCVknLAF9TqOH+K7k9WtxctmzR3vdqC9//imu+8qVSzEZmRPRO6C/cuVKktvly5fZt28fI0aMoFatWqaYowVdSClDf/WqWOVSKmHMGKZNE4nK8uXBsa6Q23eo0IE2ZdtQuWBl4lRh4L4GHx+4fBlRy/L0KbzjjRAdLeqt+/cXZS4tW8dS5+d+HH+xDRuVDdv7bKdtubY6T93Z1plt/TZho7RBqVDiWdvAD3AanHx4kvdWvEdgeCA1i9TkxJATWmVCNqNk3pKUcykn6ugfinr46e9Pp2vlrsTEx9B1Y1dNdiYJCoU2S790aYabuxcuLHa3f7+ovPD2Ft+306fDx6kpr9esEWl9JydhnpgYOUN/+rQI/BMxfLgQhJw5A+fOZWjaSSlYUNuJITDQiDtOnQP3DvAo9BEudi7ZwpdBX6YcncJPJ34CYH77+XxWP2P1sFZKKwa6i7Y0qZlUpYZcR29xus+dyJJ7cw7oaxSuQYX8FYiOj2bvnb2a128F36Lvlr7UWFSDTX6buPbiGofuH9J5v4kDepVSxbpu6/Ao5kFwRDAd13UkJNIwlVZi0mtZlxJyS8tijsUyrZ5+6rGphMeGU694PXpW7QmIhTq5E0di2b2lft7MuXVLyLKdnKC0+RllWkiF2FgYN077vFcvrfeSvoSFwaxZ4vF336XYjSsnondAX6tWLWrXrk2tWrU0jzt06EBMTAzLly83xRwt6EJKAb0sN+nenevhpZkv2r+zYAHsuSva6HhW9EShUDCy7kgA8rZaCEhMnowIEN+xmg8IEMZ3C4U6nm++i6PgJx+x6/5mbFQ2bOu9jfbl2+s9fY9iHhwfcpy9/fYa3c143919tFndhjfRb2hSsgnHBh+jqGNRox7D2Mjt6/558A+gvUhyL+LOi/AXeG7wJCwmLPmGH30kVjavXk1Wq54R8ucXfeN9fIQLfoqEh8MkoSTg22+hSJGkP69ZUxj3hYZqV9gTKFxY21rUqFl6pVI7j0yqo19+UXwPDqg5wOwyvtOOTWPacbEQM7ftXMY0GGOU/cpGenvv7CUwTPeFFYsxXu7GXFvWJUahUCRxu7/76i6Dtg+i6sKqbLi2AQmJQvaFAO0Chi4kDugBHGwc2NV3F67OrtwMvkkPnx4ZbmdnSIYeMree/lbwLZZeWArArDazkmTd5e+dbTe3aaT2iTP0ZktkpDAvyo0klttbFBY5g7g4Yc60dau2juvkScOTUn/+Kfpnly8vrolzCXoH9P7+/ty/fx9/f3/8/f0JCAggIiKCU6dOUblyZVPM0YIuvBvQBwZqZNfSF1/y+efiM+PpCWXr3eLWy1tYK635oMIHAAx0H4i9tT1v7K6hKH2SHTvg/Pmkh9i7V8isz50Th9m1J477tQbgc30T1kprtvTaQocKHQz+FRq4NqBd+XYGb5+YsJgwzj45y5xTc/Bc70lkXCQflP+AAwMOmEWrmsT96GUcbRzZ2XcnRRyKcCXwCgO2DUjufO/iAj1FhsJQczyDmTVLKDrc3GDs2OQ/t7ISZQGQTHYPWnO8DRuEUspoGKOOPjxcXDwoFOJxKgSGBWp6Tpub3P6n4z9pTKVmtZnFl42+NNq+KxesTEPXhsRL8ay5skbn7RIb45mK8JhwFFMVKKYqsqzdljmh40chw0TGRvL07VPAvDP0oJXd77i5g8p/VGbV5VWoJTVdKnXh0qeXGN9Y1MLpFdC/eQCQRGlW3Kk4u/vuxtHGkSP+Rxi5e6TBhpJx6jiNi76+AT2IFqzTWojFQVPW0086PIl4KZ7OFTsnM+CtU6wO1QtXJyouSmMYKAf25nAdkCJxcSKYrV49SceYXIOlfj5nER8vJJ8bNghn5g0bRO38vXtCzakvibPz33+fa7LzYEBAf+zYMYoWLUrp0qUpXbo0JUuWxM7OjpiYGFatWmWKOVrQhRIlRKu5QmKln4ULhSypYUM2PWrEkSMi2f7bb7DjlpDbtyzTEmdbZ0Cc3PpW7wtA6R6LAOFLAeLz9v33wqw8JET4U5w7H8/6qEFsuLYBa6U1m3ttplPFTpn7OycQ8DqANVfWMPHQRDqv70yZ+WVw+sWJBssbMP7geGLVsfSp3oftfbZjb20ePUvlgP7CM1FHL1Mqbym29U4obbi5ne+OfJd84+EJ5mXr12feCf/VK/hV1DDy66/JimsjYxOchRPL7t+hfn3hqh8TA0YV+8h19JmQoV95eSVx6jgalGhAjSJ6tljJQmb+O5Pv/hHvpRmtZmgCDGMim+N5X/bWOchwL+KOAgVP3j4hKNyYqzwWsjv+r/0BUZKVP08K7VjNCI9iHrjlcyNWHUu8FE+HCh04P/w82/tsx72ou0aBcO+V4Rl6Gfei7mzssRGlQonXJS9mnpxp0Jzvh9wnJj6GPFZ5DFbNTWo2iTZl2xAZF0mvzb2IjjNuG5OTD0+y7eY2lAolM1rPSPZzhUKh+d6Ry33MXnJ//z7cvSv6a+fGa25LQJ9zUKtFXefq1SLw3rRJ1HV2F4omg97ff/whPMUqVBDtt3IRegf0Q4YM4c2bN8lef/v2LUOGDDHKpNLizz//xM3NDTs7Oxo0aMDZdGTFPj4+VK5cGTs7O2rUqMHevXvTHG+2HDkivuCrVBFyrEUiKP/d6kvNe3riRNFqTM4gelZManQ3qt4oAJ7k9UHp9IK//4YdO4Tz+fTpCWNGwdFj8Uy5NIR1V9dhpbRiU89NeFZKbppnaq4GXqX/1v6UXVCWAdsGMPPkTHbf3q250CniUIT3y7zPzNYzWfPhGrPqY+zq7Er5/OVRS2r+ffhvkp81KtmIvzz/AuCXf39JnvFs2lQ0lI+IEEF9ZnDqlHjfVaigNTZJ4OKzi7jOc+W9Fe8R3zD1DL1Coc3SL1okEhFGIZNa10mSxHJfsRIx3MMwR/isYPap2Uw8PBGAn97/ia+bfm2S4/Su3hs7Kzuuvbimc028k60TFQpUACyy+9xGYrm9uZuXKRQKlndezqd1PuX00NPs6beHOsXraH5eLn9CQJ8ByX1iOlTowIL2CwCRwfbx0799iCy3r1KoCkqFYf7JSoWSNd3WUMi+ENeDricxp8sokiTx1cGvABhWe1iqKoKPan6ESqHizJMz3Ai6Yf6S+8Tlan/8kcyPJsdjCehzBpIkzLi8vERp5Lp10FW0uGWg8Nxh40b9ehm/fZtrs/NgQEAvSVKKJ9fHjx+TN69pvyA3btzIuHHjmDx5Mr6+vri7u9OuXTtevHiR4vhTp07Rt29fhg4dysWLF+natStdu3bl2rVrJp1nVvPk17UQFEQApfjy326o1WLB6+uv4UX4C01bm3eDcI9iHtQvUZ9YdSweQ4VLd9eucPiwKH1euxZ+/0PNZweGsfrKalQKFRu6b9D0mc4sTj86jed6T2oursm6q+tQS2oaujZkZN2R/PHBHxwddJSgr4J4Pv45hwceZkKTCWbZjipxP/p3+ajmR0xsIoKwYTuH8d/j/7Q/VCi0WfrMkt3L9RmNGiWpa3v45iEd13XkVeQrTj8+zV82CbLL27dFjdM79O4tGjU8eiQ8GY1CJgX0xwOOc+fVHRxtHOldvbdJj2Us5p2ep7kontZiGt80+8Zkx8pnl48PK38I6GeOZzHGy53kBIf7xLQq24rFnRbT0LVhsp/Jv2NwRHASRVZqJO5BXzpvytnzz+p/xtgGovRpwLYBSc8ROmBo/fy7FHYorLnWOPbgWIb2lZitN7Zy+vFp7K3tmdJiSqrjijgW0ZQCel/y1vzdzDZDf+OG9vGtW8L4OLfw6hU8SegEUb161s7FguFIEnzxBSxeLK4XV63SlooCtGghehm/fi36JOvKH3+I90iFCtC3r9Gnnd3ROaCvXbs2Hh4eKBQKWrVqhYeHh+bm7u5Os2bNaN26tSnnyty5cxk+fDhDhgyhatWqLF68GHt7e7y8vFIcP3/+fNq3b89XX31FlSpV+PHHH/Hw8OAPo/fGyh5cvAjdu0mETPkNgAWMoXNXK86fF23B8+SB3bd3IyHhUcyDknlLJtvHqLoiS/+sxGKsbETv1sqVRd18n75qhu8cjvclb1QKFeu7r6d71e6Z8rtJksSBewdoubIljb0as+v2LhQo6Fm1Jxc+ucDpoadZ2HEhn9X/jOZuzSloXzBT5mVK3jXGe5efWv1E18pdiY6PpuuGrkl7dQ8cKGzjL1wA30wIhOSAvm5dzUuvo17TYW0HnoU909QrfuX7C3EVRcY1Jdm9nZ12LcJoH9NMCuiX+YrFk77V++Jo42jSYxmD+f/NZ9wB4Sr7w3s/8H3z701+TNmkat3VdTrLby3GeLkTWX6eUwL6tHC2ddacs3SR3SfuQe9gk3ov9Tlt59C5Ymei46PxXO+Jf4i/znMyxOE+NTSeMAFHM7wvgNj4WI2qaHyj8RRzKpbmeLkn/eorq3kVKfyGzLaGXs7QOyaT9HFaAAAgAElEQVScYxYsyLq5ZDY3b4r7kiXB2Tlr52LBMCQJvvpK+7718hItsxKjVGpfW71at/2GhsLs2eLxDz/kuuw86BHQd+3alS5duiBJEu3ataNLly6aW58+fViyZAlr1uhudqQvMTExXLhwIcmigVKppHXr1pxOxTjh9OnTyRYZ2rVrl+p4gOjoaEJDQ5Pcsjtv3gizOw8PeLvtINXxI9LKkSH/DmPbNqijVfalKreX6VWtFy52LjwJD2DC0n1MnSrM0itXUTNi9wi8LnmhVChZ220tPav1THEfpmDAtgG0W9OOow+OYq20ZmjtodwcfZNNPTfhUcwj0+aRmcgGP77PfDUywcQkdr4PDA/Ec30i5/uCBaFbQss0U2fpJSlZQB8TH0P3Td3xC/KjuFNxLn56kbrF6xIaHcrJkgn10ynI7gFGjhTf50eOJDPDNwxjmOKlQ0hkCJuvbwbMwwzvz7N/8sX+LwD4ttm3aWa4jEmrMq1wdXYlJCqEXbd1k2BkhjGehezH/dfm73CvD5o6eh1k92nJ7ROjUqpY130dtYvWJigiiI7rOmoy1OlhrAw9QPPS4lx24ekF3kZn3J196YWl3H11l8IOhXXy++hYsSMF7QvyLOwZ229tB3JAhv77hAXYvXuFgVhu4O5dcV+hQtbOw4JhSJJoIzdnjni+ZAkMHpzyWLl3/N69Kao5kyFn5ytWzJXZedAjoJ88eTKTJ09mxYoV/Pjjj5rnkydPZtKkSfTt2xcbG9PVKAcHBxMfH0+Rd1phFSlShOepXKg/f/5cr/EAv/zyC3nz5tXcSpZMnsXObjg7C4myUgmzis0FIM9nQ6neJOkJKyI2ggP3DgDQpXKXFPeVxzoPH9cWTcYvWy/ihx/AwVHNqD2jWOa7TBNEZqak+NnbZ6y9uhYFCr5o8AX3x95nuedyKhaomGlzyArSqqOXkZ3vCzsU5nLg5aTO93Kqe+1a4fxpKp48EV0VVCpwd0eSJIbtHMYR/yM42jiyp98e3PK5sbDDQhQoWOWQcFJOJaAvVQq6JLw9//zTCPPLBFO8NVfWEB0fTc0iNalXvJ7JjmMMFp9fzOi/hVnBxCYT+bHljwbXKD9/LjoVXrqk23iVUsXAmvr1pJcz9Hde3TFKMGDBPMhpkvv0kOvo5d87LXQN6EGcI3b13UUJpxLcCL5Bj009iI2PTXObeHU8N4JF4GiMgL5k3pKUdSlLvBTPyUcnM7Sv0OhQph6bCsCU5lNwsnVKdxsblQ39a4iM3/Mwcf1nljX0arU2oO/SRRgcSZKRTpRmgCWgN29+/BF+/lk8/v13YYiXGtWqiSxlbKyopU+Ld7PzqvRLbE+cgPbttd29cwJ619APGjSIqKgoli9fzqRJk3iV0C7N19eXJ3JtixkzadIk3rx5o7k9evQoq6eULgoFLF0Kd3f44f5sv3hhTPL+0YfuHyIyLpJSeUvhXsQ91f19WudTQPSM9g/xZ/Te0Sy5sAQFClZ2XUm/GpnrHClfANQsUpN57efh6uyaqcfPSlq6tQRSrqOXKZW3FNt7b9c4339/JGHlvkULKFdOGIVs2mS6ScrZ+WrVwN6eKUenaDwWfHr6UKtoLQDqlajHcI/hnEpYI5POnRNf1ikgm+OtXCkUKBkicYbe0L6mKhV06CBu75wsJEnSyO2H1R6WrQ28ll5Yysg9IwH4qvFX/NzqZ4Pne/Gi6HgxYwaMGKH7doNqDQJg3919PHub/iJLIYdClHAqAcDlwMsGzTUtVEoVHSp0oEOFDmbptZHZpPFRMBqSJOW+gF4Pp3t9AnqAEs4l2N1vNw7WDhz2P8yoPaPS7DQR8CaAqLgobFW2lHEpo9Mx0iMtTxh9mHVyFkERQVQsUFEvNZRc7iNjlpL7R4+E2a21tTi3y9d5Xl6mXbTPLty5I+7Ll8/aeVjQn19+gcmiLS5z52ov8tJCNsdLT3a/YIFowVW5MvTpo9N0zpyB/fsN64yXXdE7oL9y5QoVK1Zk5syZzJ49m9evhXxr69atTJo0yegTlClYsCAqlYrAwMAkrwcGBlJUzsC9Q9GiRfUaD2Bra4uzs3OSmzlQrx6U2SFq5/nwQyib/CIosdw+rYv4CgUq0KZsGyQk3l/1PovOL0KBghVdVvBRzY9MMv+0kLPTTUs1zfRjZzVy7eG+e/vS7JHdqGQjlncWDus///sza6+sFZKNzDDHu3BB3Neti9dFL6YdF72HF3daTPvy7ZMM/bnVzwS5uvDKDhSRkXA55QCtZUvRsCE83AideeTPe2ysaGdiCHZ2sGePuL3Tku/c03NcfXEVW5Vtlnw+dEGSJGb8O4NPd4vFunENxzGz9UyDg/mtW0UzhcePoQDBnDsTz/30E4sAVCxQkSYlm6CW1Ky+olt9nFxWYwrZvZ2VHXv67WFPvz3YWdmlv0EuJ42PgtF4FvaMqLgoVAoVpfKWMs1Bshl6Se5T6EGfHrWK1mJDjw0oFUqWX1zOrFOzUh0ry+0rFayEldI4tahyCVlGAvqnb58y57SQ685oNQNrlbXO29YqWkuzuAxmKrmXa9AqVhQ1wu3bi+D2zRswYclrtsGSoTdP5s6FbxIMd3/5Bb78Urft+vYVq8ZnzggDyJR49kzsH3TOzoP20tM99dym2aF3QP/ll18yePBg7ty5g12is3mHDh04fvy4USeXGBsbG+rUqcPhw9q2J2q1msOHD9OoUaMUt2nUqFGS8QAHDx5MdbxZExSkXcVK4cMSr47X1KymJrdPjNzCTs4ELPdcrsmsZTZyhr5JySZZcvyspIVbC6yUVlx7cQ23+W7M/Hemtk7+HQa4D9A43w/dOVS4Gg8eLE78//0HV6+aZpIJGfrrpe01AeM3Tb9JMXtSwL4Av7SZyemELP2bI3+nuMvELewy3JnHxkZY54NJZPdyq7oeVXvgksfF6PvPKJGxkXy07SMmHRYLruMajmN229kGBfOSBD/9JLpmRETARI8DBFKE6XzHhg2672egu1h5l30H0kPjdP/c4nSfG5Cz86XyltIraDNn9Gldp2+GXqZTxU781k4s/H996Gu2XN+S4jhj1s/LyHX055+eT/Uclh6T/5lMZFwkjUs2Nqi7jtyTHsxUci/L7atUEfdKpWj9BeJEaagCLbORJPj2W1i4UL9tLBl68+OPP+B//xOPp04V/bN1pXBhsWgFyResnj4VsU65ciI7X6UK9Oql864tAT1w/vx5Pv3002SvlyhRIs3adGMwbtw4li1bxsqVK7lx4wYjR44kPDycIUOEg+nAgQOTqATGjh3Lvn37mDNnDjdv3mTKlCmcP3+e0bpIPcyNRYtEv8a6daFJ8sD37JOzvAh/gbOtM++Vfi/d3XWq2EkjdVzWeZmmrj6zCYsJ02TlcmOGvrhTcTb33Ew5l3IERwQz8fBE3H5z45cTv6TY3uinVj/RpVIXrfO9XbS2IN0UWXpJQn3+HACfPltGnDqOfjX6Mf396aluMtRjKA+ribKJGzv/SnXcgAHg5CQ63B3OaPtiExnjhcWEsf7aeiB79p5/EvqE5t7NWXd1HVZKKxZ1XMScdnMMCuYjI4Xx7Hffieeffw4/5Z+NCjXvc4T163Xfl9zG6tzTczrJ7i3GeLmL3Ca3B22G/uGbh8TEx6Q51tCAHuDzBp/zef3PAfho20ecfXI22RhjOtzLlM5XmjL5yog6+of619H7vfDD65LoaDSrzSyDvsP61+yPtVIsEBWyL6T39lmOnKGvmuj/MmQIODiAnx/8k3JHnGzHxYuilnrMGIiK0m2bly+19XcpKFCzhAxlGnIBS5aICwUQCzjfG9BJRzbHW71a/L0fPhSLWGXKwG+/iQuTevVgwwads/MxMdq1sZo19Z9SdkXvgN7W1jZF5/fbt29TqJBpvyB79+7N7Nmz+eGHH6hVqxaXLl1i3759GuO7hw8f8ixRBq5x48asW7eOpUuX4u7uzubNm9m+fTvVc1r/yqgorSnKuHFJ+oDL7Li1A4AOFTpgo0rfvNBKacWJISe4POJylrp2n31ylngpnpLOJVNss5cb6FK5CzdH32Rl15VUyF+Bl5Ev+ebIN7j95sb049OTOOArFUrWdFtDzSI1CQwPpMuGLkQNTvSFGBlptHm9jX7L7z5foQx+SYwSzhaMpn359nh5eqV5saVUKHm/r5BfFb8awPGAlJU9Tk5aA9QMt7DLqDFeeLi4aHJwEI8T2HhtI2ExYVTIX0GnhbLM5OyTs9RbVo9zT89RIE8BDg44yIi6ehS7J+LZM2HJsH69OGcuWgQLvriP8tBBAMpyn2vXdBeBFHUsSv0S9QHYc2dPuuPlDL1fkJ/O7e50JTwmHIefHXD42SFZWcvTt0/5Yt8XBgUgOZVUPgpGRa4jzy0O9yA+E3ms8qCW1Jq2dCmhSw/69JjXbh4dK3QkKi4Kz/WeyY5nigw9ZEx2P/HwRNSSmm5VutG4ZGODjl/QviAbemxgfvv5RvMGyFTezdAD5M0LgxLUk+bSwk42xI2P12bd00OW25csKXowZzVPnkDx4tA78wyizQovL625zvjxwhDPkBI/T0/h/B0QIJJT5csLZUdMjKj7279fSPL1iMxv3IC4OMiXT7ydcgp6B/Senp5MmzaN2AQzK4VCwcOHD/n666/p3t30PclHjx5NQEAA0dHRnDlzhgYNGmh+dvToUby9vZOM79mzJ7du3SI6Oppr167RoUMHk88x01EohNlEy5bQo0eKQ+SAvkul9OX2MsWdilOzSNYuX+Xm+vnEWCmtGOg+kOufXWfNh2uoVKASIVEhfP/P97jNd2Pq0amaizxHG0d29hHO95eeX6L/W2+k0qXh9WvYrJvEOS2i4qKYd3oe5RaU4+gWUc94t4QdPh/tYG+/vdha2aa7j0odBqBWKigVCtPWDE/VdXmUqPxg1y548CADkzZGL/qICHFLhMYMzyN7meGtubKG91a8x7OwZ1QvXJ2zw89q/Bj0xdcX6tcX7StdXODAgYTz9F9adUUhgnEiVK8sfacKnQDYfXt3umNL5S2Fi50Lceo4/IL89P0V0iUiNoKI2Ihkr885NYf5Z+bTbEUzxvw9xmCpsDny6M0jfj7xMyGRIcl+lsJHwajILetyU4ZeoVBoft+0ZPe69qBPC5VSxfru6zUtTzuu66hZGJYkyWQBvWyMdyzgmF7bHX1wlN23d6NSqPil1S8ZmkO3Kt0Y0yC5aXC2R5JSztCDtj4twyfKTCJxhxtde9NmN7n98uWiu8+WLbnDkFAf1qyBYQmJwDFj4NdfDQvmQSze9Exokb17t/BCev99oUY5fhzattV731euiPuaNQ2fVnZE74B+zpw5hIWFUbhwYSIjI2nevDnly5fH0dGRn376yRRztJAetrYi8jlyRLifvsPtl7e5GXwTK6VVMpOy7E5urp9PCSulFf1r9sdvlB/ruq2jSsEqvI56zZRjU3D7zY3J/0zmVeQrSucrzbbe27BR2bD19nYOv+8mdpAB2b0kSXhd9KL8gvKMOzCOoIgg2rwSTsFV2g/As1LaZotJcHREXaMGAPkv3eaPsymn4CtXhjZtxLXMokUGT904Af07XA28ypknZ7BSWjHIPWv8Jd5FkiQmHprIgG0DiI6PpnPFzpz6+JTBgdGWLVrzu8qVRVD//vuI5e0VSdvOlcGfDRt0L+PsXKkzAAfvHyQqLm3ZpUKhyBLZ/SH/QwBISPx+9ndqLKrB4fsZrf8wD4buHMq3R75l4PaBaTqim4LcKLkH3VrXZURunxgnWyd299tNcafi+AX50dOnJ7HxsTwKfUR4bDhWSivK5zdu8CRn6M89Pafz4phaUvPVwa8A0YEnp7erTZXAQLEor1QKU7zEVKkCrVsLSbI+delZhSEBfXYyxFOrtee/+HhxYsythIXBsWMwa5aoYXdzEzJ5SYKRI4UsPqNR85dfin7GH3wAJ0+KGswWLQzeb06snwcDAvq8efNy8OBBdu3axYIFCxg9ejR79+7l+PHjODgYtlpswbTI7vYt3FqYVauWeHU8px+JnhK5PUP/Liqlir41+nJt1DU29thItULVeBP9hmnHp+H2mxvfHfmOSgUqaZzvB7kcQ61UiOabsmxPD0KjQ+np05OhO4fy5O0TXJ1dWdZ5GZ9IdQBQ1NO/97pV02YANHoMk49O5unbpymOk5MPy5dnoGLABDX0shmeZyVPijgWMdp+M8Lm65uZeXImAJOaTmJ7n+069Wl+F0kSCrkePcTfvF070d5FkxzZs0csjhQqBLWEc3RV2/v4+wv1my64F3HH1dmViNgIjvgfSXe8R9EEp/vnmRPQvwh/wZVAsZS/tttaSuUtxYPXD2i9ujWf7vo0SalLTsP3mS8H74tyit23d7P26tpMPb4suc91Ab0OreuMFdADuDq7sqvvLuyt7Tl4/yCj947G74VQwFQsUNHohoRu+dwonbc0ceo4Tj06lf4GgI+fD+efnsfRxpEfmv9g1PmYFfJ5u2zZlNtLyLXKy5ebVj6TUZ4+FfJpGXPM0B85kvR3OJlLSrJiYkRXo0WL4OOPoXp1UfLRogVMmAA+PuLvolCI9+MffxgnBV6tmtjv3r3Q2LBym8TIAX1Oqp8HAwJ6maZNmzJq1CgmTJhA69at8fX1pVOnTsacmwUjIEmSxklaH7l9duDqi6u8jXmLs60z1QvnMN8DI6FUKOlVrRdXRl5hc8/N1CxSk7cxb/npxE+4zXfjetB1Pq//OU+dYU/FhC/W5cv1OsbVwKvUXVqXLTe2YK20Zmbrmdz5/A7Dag9FKbesq1NH/8knfDG3DXTgbcxbTRbmXTp2hNKl4dUr9HJST4KRM/RRcVGalmvDamedx8S7rLy8EoDxjcbzc6ufUSr0/4qPjIR+/UQHGBCKud27Rb2ZBlnpMWQIVKoEQKeqIquoq+xeoVDoJbuXM/S+zzLH6f4ff2EwVbNITfrV6Me1kdcYVVfUgCz1XUr1RdXZe2dvpswls5EXhWTjsDF/j+F5mGlNb2XCY8IJDBftZuWMdW5Bl9Z1xgzoQbSEXN99PQoULPVdysTDwoXa2HJ7Gbn059iD9GX30XHRmu4cExpPyDYLp1mCHPgmrp9PTMeOwigsJATWrcu8eemL3PhbmXBu0jXBIGfos0NA7yXMGcmfX9zn1IA+IEDI58eMgYYNRS173bpCEbxihTBiVKtFIXr37jBzpljseP1a+DkoDQ4xTYosuc/VGfr9+/czfvx4vvnmG+4nNB2+efMmXbt2pV69eqgtjo/Zju03t3PmyRlsVDZ8WPnDrJ6OXsj18w1dG6JS6uZemVtRKpR0r9qdi59eZGuvrdQqWouwmDBmnJwhZPL5y7Oktvh8xnuvEB0RdGD15dU0WN6AO6/uUNK5JMeHHGdCkwmiX/f9++KL28ZGrNTqS0JAX/VRFHliYd3VdSmaJalU2lr63383sDNPRk3x3mHrja2ERIVQ0rkkbcu1Nco+M0pwRDD77+0HRCcBQ3j6FJo3FwsnVlbCpHb+fPFYw6NH8HdCu8FhwzSOw02KiXPCpk1ChagLsux+9+3d6cq6ZWO8y4GXiVfreIAMcNhfSOtblWkFCInynx3/5Oigo5RzKcfj0Md0XNeRNVdyVv/nu6/uahaB9320j9pFaxMSFcKoPaMyRXrv/9ofABc7F7NSlBkDXVrXGdKDPj08K3kyr908AI0qxZgO94mRA/qjAUfTHbv4/GL8X/tT1LEo4xqNM8l8zAY58H23fl5GpdK2sDP4RJkJyHJ7uR3Z7duiLjotEresy2rJfUgIbN0qHv/6q7g/fVr3k156nD0r2lBnNb6+4tw+YIB4P505I64bXVyEZO+772DnTnFN9fCh8GeaMEF4eTk7Z/XsU+X5c3jxQqw1VKuW1bMxLjoH9H/99RcffPAB3t7ezJw5k4YNG7JmzRoaNWpE0aJFuXbtGnv35sxshbkSGRvJuAPiJPhV468o4Vwii2ekH3L9fNOSFrm9rigVSj6s8iG+n/iyo88OPIp5EB4bzt1Xd9lfHh47gepVCFE+aadRo+KiGLF7BAO3DyQyLpK25dri+6kvDV0bagcl9J/H3V0E9fpSujQUK4YiLp7pTqKn8Gd7P0vRIG/oUKEyvHgR/vtP/0MZO0Mvy+0/rv1xtlls8vHzIU4dh0cxDyoXrKz39rL53blzIvFw4AB88kkKA728xKp8ixbi4iohoC8V70/+/OKEefSobsds6daSPFZ5eBT6iMuBl9McW7FAReyt7YmIjeDOKx2dkTOAXAYgB/Qyzd2ac2XkFQbUFN0jMluObmpmn5qNWlLToUIHPIp5sKLLCqyUVmy7uY1NfptMfvzcKrcHbYb+fsj9VBdPjJ2hlxnTYAyf1ftM89xUGXq5H/25J+eSdZVIzOuo1/x4/EcAprWYZrABYI4hvQw9CBm0nZ1IQV5O+/s0y5AD+t69RauM2Fi4l/oCFiDkea+F6W+Wt6xbt04EtjVrijY8Tk4QGiqy1RnFzw8aNAAPDwgOzvj+MsKuXeI8X7o0fPGF+L3v3BHtA/ftEzV5nTtrkyVmgvyxqFAB7O2zdi7GRueAfv78+cycOZPg4GA2bdpEcHAwCxcu5OrVqyxevJgqaX3JWMgSfj35Kw9eP6Ckc0kmNZ2U1dPRGzlD36SUxRBPXxQKBZ6VPDk//Dy7++6mXvF6xKngL1GGjO+Po1Ls/x2vjudW8C2aejVlyYUlKFAwuflk9vbbS0H7gkkHywF93bqGThIaNQJgRKw7Be0Lcj3oOgvOJG+9U6AA9O0rHhvUwk4O6MPCDHOkVSpF6rp5c+699uefB/+gQMHHtT82YDKmQQ4s+9for/e2mzcL87snT4T53ZkzYqE9GfHxWnf74cPFfcIFlvLBfU2TDV1l93ms89CmXBsgfdm9SqnSdN0wpjGeUqGkeenmNC/dXFOiEPA6gHsh91ApVDQr3SzZNvbW9hqn7DOPz2S6aZypeB72HO9L3gBMbCKk1+5F3fm22bcAjP57NC8jg+SPgkkUlbIhXG6T24Po1a5UKImIjUi1xMFUAb1CoeC39r/Rt3pfSjqX5P0y7xt1/zJu+dwolbcUsepYTj8+neq4mf/O5GXkS6oUrMKQ2kNMMhezIr0MPYjsqdzJycfH9HPSl6goUYMN0KSJONlA+rJ7WW7v6pr1UZgst//4Y6GKaJiQ5DCG7P5iwnnt8WPo3994WX9DOHFC3E+cCPPmiQuw8uXN3hY+p8rtQY+A/t69e/RMaB3QrVs3rKysmDVrFq6uriabnAXd+cf/Hz7Z9YnmwvLB6wfMODkDgNltZ5vd6vbDNw95HPoYlUJFgxIN0t/AQoooFAo6VuzImWFn2NtvLydalUcNNL4dSasf3Gjh3QKPJR6UmV+GfDPyYfWjFZX/rMyFZxcokKcAf/f/myktpqSchc5oQA8a2b39uYvMbC3qdqccm5KiQZ5sjufjY4C3nZOTyAaAYcZ4efKItPPRoyy/IQLnduXbUSpvKf33ZQIevH7AyUcnUaCgdzXd++JKEkybJrrCREYKFeR//6VRpnjggJDc588P3bqJ1+SMib8/fXuLso4tW3Su6qBzRSG733V7V7pjZdn9wfsHjRZE57HOw9HBRzk6+Ch5rEV/Y1luX79EfZxtU5YP1ixSEzsrO0KiQjJFMZAZzP9vPtHx0TRybZTEiPSbZt9Qs0hNgiOC+eroaPmjYJJ20BqH+3y5L0Nvo7KhpLNojJyS7N4YPejTwkppxbru6wj4IoBCDoWMvn8Q5yQ5S59aP/pHbx7x25nfAJjZeiZWSqsUx+UaQkK0563K6aivevUS95s2ZT/Zva+vyMgXLizOG/LiRHrGeNnFEO/SJfE72NjARx+J12STNmME9IlbDh44AFnVOSwmRqukaJZ8QducyamGeKBHQB8ZGYl9wsqYQqHA1taWYnLWy0KWEhwRTKf1nVjmu0xTz/m/A/8jKi6Klm4t6Vm1ZxbPUH/k7HztYrXNbjEiO6JQKPigwgcc/O42t+qVAWDguRiOBRzj4vOLPHj9gDfRWtfu5qWb4/upL+3Kt0t5h2q1dqXdCAE9p04x2H0QDV0bEhYTxvgD45MN9fAQCf3Y2LS778XHw44d2msADUaQ3cfGx7LikmhXM9xjuMH7MTbrr4qUeMsyLXUurZHN7yZPFs+/+EKo7PLmTWOjpUvF/cCBWqdlV1dRZB8TQ7NyTyleXKgj9+/Xbe4dK3QE4OyTswSGBaY5Vm67ueLSCsYfGI9aMo1vy7v18ylho7KhTjFhBvnfY0PqQLIXb6LesPC8aHk1senEJC0obVQ2rOiyApVCxSa/TWy5vsVk85AD2dwouYdEdfQpON0bowe9LujcftRANMZ4qfSj/+HoD0TFRfFe6ffoVNFitqzJYLu6isXptOjYUXw3370rAtDshBwkNm4sMr26BvTZxRBPzs536SJkgyCUBmCcgN5f+IfInWOYMgUOHsz4fvXF11dcIBQokHaJhxliydAnsHz5chYsWMCCBQuIi4vD29tb81y+Wch8CtoX5Pv3vgdg3IFxbL2xla03tqJSqFjwwQKTn5xNwcmHlvp5U6BQKKgyaQ4Agy+BncKaVV1XcXroaW5+dpPA8YFEfxfN0cFH084+370Lb9+KC4e0JIDp4eEhVruDg1He9+fPDn+iVChZf229xmU8MXKWfvHilH107t0Tpd1du4rz7KtXiX5oBGO8PXf2EBgeSGGHwtnmQlOSJL3l9u+a3y1dKlR1Vmklwp49ExE/aOX2IDYqLbKFqoD79E4QCOgquy/mVIy6xcWi0J47e9Ic61nJk1ltZgEw97+5DNw2kJj4GN0OpCOSJGnr58umHtADGk+JnBDQL7mwhNDoUKoWqprie9ujmAdfN/kagFF7RxEcYZoaz9wsuYekdfTvYiq5fWYjB/RnHp8hIjZpi7UrgVdYeUl065jVZrpCNgoAACAASURBVJZZXr8YHTng1eVc6+gognoQWfrsROKAHrTBoq4Z+qw0xIuKEo7vIEx9ZBo2FLVHDx6IE2tGkDP048aJc6wkiVX3x48ztl99keX2TZtmW6d6Q4iO1q6N5eqAvlSpUixbtox58+Yxb948ihYtyurVqzXP582bx2+//WbKuVpIg/81+h/VC1cnOCKYj3eIut7P6n1mtu3eZEM8S/28CejUCcnFhaLhUM8/lkP+h2jo2pBKBStR2KEwNiodDO5kuX3t2ulEgelga6vN8J86hUcxD0bWHQmkbJDXowcUKSLOm9u3a1+XJNEatWZN+FeIOwgKgkmJrSMykqEPD4dChWhZvzf2MTDIfZBuf6dM4ErgFfyC/LBR2dCtSrd0x1+4APXqac3vDh5MGp+nire3kD80bpz8wlKW3d+/r/E62LlTd7sCfWT34xuPZ1XXVVgprVh7dS2e6z0JizHAFyGB8JhwCs0qRKFZhQiPCed60HWehz3HzsqORq6N0txWLgc68+SMwcfPDkTFRTHvP+FyPqHxhFTbHf7Q/AcqO9fhxeRruBazITx1TzODUEtqjct9rs3Qp9G6LqcE9GXylcHV2VXU0T9KWkf/9aGvkZDoVa0X9UvUz6IZZjPkKETXbGl2lN1LkrZlXYJ3juY8cvNm2vXi2SFDv2OHKH1wdYXWrbWvOzlp9dsZzdLLAb2bm2j7Vru2MMfr3Tv9TgDG5Phxcf/ee5l3zEzgxg2IixMteHNitbjOAf2DBw/w9/dP8ya3srOQ+VirrFnSaQkAb6LfkNc2L1NbTs3iWRnGm6g3mtY5TUpaAnqjY22NorMIoD68Casur+L80/P67cMY9fMyiWT3AD+2/JFC9oW4EXyD+WfmJxlqY6N1Xv/9d3H/+LHoojJqFEREiAy9vJC+dKk2KZBhyX1wMHnfimzwMI/s03tezs53qtgp3TZfPj6iJO7pU3FtePas+Huli/r/7J13XFPnF8afhLD3UlFkqODEgXsPrBMVt9a6R60/N9o6K45aW7VqtbWtq47aWuvCvQXELS4ciCgoCqKoDGUm9/fHyc0NkMDNAsT7/Xz45JLc8YaR+573POc5MmAjOfurjP6VAvpGjYCqVel3ERzM7z2wGeGTMSeRmZtZ5P5D6w1F8KBgWBhb4HjMcfht89MpY/z6w2vF8Wx2vpVbK5hKTAs9js3Q30q8VSDT+DGx7dY2JKYnwtXGFYN9Bqvdz1RiSveZD87ISrXBzBMz8eq9/losPU99jmxpNiRiCVxtyuCMiweFta4rKwG9SCRSKbs/9fgUjj06BmOxMZZ2WFpCoyuFaJKhByhDb25OrWVv6M9AVCdiY8kHwNgYaEilSvD0pEX9zEzqea4ONqAvyQw9K7cfMYLM8JTRh+xeKqX2bwD9XMzM6IZta0uTmFmztD+3JshkXFakjAX0ynL7sij8KTtaCgFUsa8CY7ExAHJhtjD+OHsyXIq/BAYMqthXgYu14NNgEHr3BgAMfWQJMMD049M1MxnTZ0DPrtbLI297c3v8+Bn1dw06F4T41Lxysy+/pPtpWBiVmNWpQ1lmMzPqmX76NBnEjpIb0I8fL1/cZgN6bUzxlGjl1hLejt46nUNfyBgZ/o4kbXtRcvuwMErcZGQAXbtSsqQqX1XzmTM0ObS15bI/yniSLwMeP4ZIxHUk4Cu7b1ChASpaV8T7nPdqjbLy09WrK04POw0HcwdceX4FrTa3UtQY6wKf+nkWVxtXVLSuCCkjxfUX13W+dkkglUmx/AKVMQQ2DyxSedKwYkPF9vprv6LKz1Ww4OwCpGal6jwWVmbuYefxyRqhKTL0KmroDdGDvqRo594OAGeMJ2Nk+Prk1wCArxp99cmWXKhE0wy9pSXgLy+bKS2ye3Zl3deXc9OUSIDq1Wlbnez+zRuudq6kWtbFxXG17CNVdFzQR0D//Dmlj42NublK1aqkjAOAn34C9u7V/vx8iYwkExwrK66Wv4xQlg3xACGgL1PMOjULObIcSMQSJKQnYHn48pIeklawhnjKLssCeqZTJ8DCAk6v36P5K1OEPQ3D3vs8bxZSKZmmAPoN6CMjgRQy5htWbxhaVG6B9znvCxjkVarEGawvXEiHNGlC/j+TJ3MlXz/8QJ4ud+5QoK9Lhl4q4+SAI+qN0Ph4QxEWF4b41HjYmtqim1e3QvfdQl5+6NuXh/ldflgXwiFDVLcNUsrQA1xAf/x4Ph8DNYhEIvh70QT0YFTRsnuWZq7NcH7keVS2qYyo5Ci03NwSkUmRvI/PT64sVxFg8AnoRSLRR19Hv/f+Xjx68wj2ZvYaK0/qV2iA9Ox0LApdhCprquCniz/xUlioQ+Fw/4nK7QHuvb/68AppWWl5XisrGXoAaOtBTveXn19GRk4G/r7zN24k3oCNqQ3mt51fwqMrRaSnc9lrTfxq5F2pSo3sPn/9PAu7SKGudR2bna9YketUU9xs3Uo/w/btVS8qsAH9jRvQug6Jldu7ueVVAAQEADPkc6CRI1W4/eoZVm7fooVu5ZSlkLJsiAcIAX2Z4eKzi9h6i4xkvm3zLQBgcehiPHrzqCSHpRWK+nlBbm84LCwoTQvg+5TGAICvT32NrFwevcaiouimZWnJra7rgosLZXgZhhqgg3qDswZ5u+7uwunHp/McMmUKSaaMjYElS2hhPP9QnJyA5fI1rQULgCSx9qZ4F55dUGwH1AjQ+HhDwcrt+9bsCzOJmdr9cnI4z4GJEwsqBgvl1Stg3z7aVldsr9S6DqB5Z926dN09PA3Re1SnMpBD0Yc0UovUdK6J8FHhqOVcC8/TnqP1ltaKRUFNuZl4EylZKbAzs4Oviy+vYz7mOnqGYfBDOLWLnNRkEqxMrDQ6PmxkGHb3343qjtWRnJGMwBOB8FrrhY0RG5Ery9V4PAqH+0+wZR2LrZktHM3JQTu/7L4sBfRV7auiknUlZEuzcS72HOaemQsAmN1qNpwsnEp4dKWIqCh6dHbmnNX50K0b3eefPOE60pQk+evnWYpyui9pQzyZjFsNVzbDU8bNjYqypVKqY9MG1uGeVbsps3QpGdSlppKRUEaGdtfgA2uIp6XcPj6eDHb37aPud6UFhhEy9AIfAVKZFJOOTgIAjKo/CvPazEPHKh2RJc3ChMMT9NavuTjIkeYoMl1Cht7AyGX3ra+/gouVCx6/fYy1V9YWfRwrt/f15RUZJqQloMa6Guj7b1/1f4vsqv1FziCpfoX6+F/j/wEAJh6dmMfNvGVLCuLv3QPmzlW/kDx8ONWMf/gAfLdZ+ww9W1cNQNGr3NAUtbiSlZuF/+79BwD43OfzQvc9e5b8fJydtWgru20bReaNGqmX4LEBfWIi/bDBZen/+YffZfw8/WAuMcfTlKe4k3RHoyFWtq2MsJFhaFG5Bd5lvsNn2z/TKNPPwmbn23m0g5GY36rHx5yhP/3kNK4nXIe5xByTmk7S+HiRSIR+tfohckIkNvXchMo2lRGfGo+xB8ei9q+18e/dfzVqLShk6AlVresM3YO+uFGuox9/eDziUuLgauOKKU2nlOzAShts5lrTbjKlSXafns5FU5oG9CVtiHf2LGXPbW05aaAqdJXdKxvi5cfYGNi1CyhXjtLMbLsffcMwXIZew4lCVBSVOVapQib9ffqQmnLq1NLRPTExkXITYjGVaZZFhIC+DJCalQoXaxfYmtri+47fQyQSYX339TA1MsXJxycVNbYfAzcTbyIjNwP2Zvao4VSjpIdTtuneHTA2hvhBFNZ50g1icejiok2uNKyfn3R0EqKSo7D3/l5FAFqAfMZ4LIvaL0I5y3J48PoBVl/K20WjefOi7/FiMbnfSyTAznPygP71a40dY9X1SzYUYXFhcF7ujPZb2yMhTfUCxLFHx/A28y1crFwUE2N1/Cf/sffpo2F2nmE4uT3rRqgKe3uyjgUUmQa21D4khG6kRWFubK5oE6dNMO5g7oCTQ0+iu1d3ZOZmoveu3th8Y7NG59BEbs/S0KUhjERGeJ72vIDfQ2nnx3DyqhjdYLROWVGJWIJRDUbh4aSHWNV5FZwsnPAw+SEG/jcQjf5ohGOPjvFaWP7UW9axqHK6L64e9MVJW3eS3T9NITOwxe0XF9uC6UcDG+hq0w+c/RDevbtkZfdXrlCmm81kK8MG9Pfvqx5jSRvisWZ4n3/O1f6DkvE//AAcOSJ/gg3o881heFNYQA9QycHOnTSp2byZG5c+efSIIl8TE6pj5MG1ayQaqFmThAw5OTQ3c3GhqdaaNWTWX78+bfOZCxgCVm7v7Z3n11im0Cqgj4mJwbx58zB48GAkJSUBAI4ePYq7d+/qdXAC/LA3t8fBwQdx+6vbKGdZDgBQzaEa5rWZBwCYdnwa3ma8Lckh8oaVyrZ0a6m2dZKAnrCzAzp0AAAEPGBQv0J9pGalIuhcUOHHaRDQ73+wH3vuc5rrmSdnqq6xZQP6S5fytK+xM7NT9B1fFLIIz1KeFXnN/NSuTSVoyXBEDuSp/JcveR+fmpWKKwnXcLUikNWgrsH7sqZnp2P4/uFIy07Dudhz8P3DF2FxYQX2Y+X2g+sMLjSbnJvLKebZskrehIXR0rulJTBoUOH75qujr1KFRBxSKXX84QPbvu5Q9CENB0pYGFtg38B9GFF/BKSMFKODR2PZ+WWFBpNikRiNKjaCr4svLsaTQqSDZwfe17Q0sUTd8qTh+5iy9Ldf3sbJxychFokxvfl03seJxfSv36hRwX8FM4kZpjabiseTHyOobRCsTaxxI/EGuv7VFe22tstTuqIKheT+U8/Qq+hFX5bk9izKC5E+5XwwtO7QkhtMaUXbDD1AZXWWlhQsXtOwk40+UVc/D9CqvJERkJZGxnD5YSX3JZGhf/eOqxljXXblbN5MxvN9+8rbxLMB/cWLtHihKazkXl1ADwB+fsCiRbT9v/9xqgd9wcrtmzYll2E1MAyZD3fsSC1w9+yh53r1ord/4QIZ9h85QnMOExMa6tSptC7Ruzd1wCnOTnxlXW4PaBHQh4SEwMfHB5cvX8bevXuRLm80fOvWLSxYsEDvAxTgj5utW57vZ7aYiZpONZH0PgmzThVTywsdEernixm5hEy8/wB+6vQTAOD367/j3is18rfcXK4NThEBfUpmCv53hCTzU5pOgauNK+JS4rDq4qqCO9epQ66qqakFpHdD6w5FK7dWeJ/zHoEnAjV4cxzz5wPuHmIkQvM6+tC4ULyXyDBwZlUYX7tl8OXdmSdm4sm7J3CzdYNPOR8kpiei/db2WHVxlSIwTc1KVfRsL0puHxJCK+WOjkDbthoOhs3ODx5M/XYLI19AD9DKPUAJIj509+oOALgcfxlJ75M0GakCYyNjbO65Gd+0/AYAMPv0bEw/Pl2t9Nvc2BxXx17Fis9WIEuaBRcrF9R00iwbpqijj/946uhXXlwJAOhXqx887VXUbarB3By4epW+1P0rWJtaY0G7BXg85TGmN5sOUyNThMaFouXmlujxdw9FW1JlUrNSFa0DP/mAXkXrurIY0FdzqKb4Xf/42Y+8y1w+KXTJ0FtYlA7Zvbr6eYCiPTb7rkp2X5KS++BgICuLsgINue4eHz6QLw9AHffmzwdFipaWtAigrnygMNgMvaoaemVmz6aFmsxMusHKjYT1QhFye5mMjPabNqVg/vRpWosZNgy4e5d8eppRBRokEhrmv//SdGvdOpoy5ubSfr16kVgjMJCMiw1NWTfEA7QI6GfNmoUlS5bg5MmTMDHh2tt06NABly59PNmJTwFTiSl+8/8NAPBHxB+a9xovZhiG4TL0QkBfPPTqRe5yV6+ivaQaelXvBSkjVbQPKsC9e3QjsbEp8gY769QsvEh7AS8HL3zv9z2W+S0DACw9v7SgjFwi4SRe+SRrIpEIv3T7BUYiI+y+txsnY05q/DYtLIBffoEioI+9yD+gZw35np7zQ/362t2r+XIi5gR+u07/s3/2+hMXR1/EEJ8hkDJSTD8xHYP2DEJaVhr23d+HzNxMVHesXqR5Gyu3791bQ9PaN2+4SFydGZ4yhQT0p08DyclFn6KSTSX4uviCAYPDDw9rMNi8iEQiLOu4TLFItfryagzdNzSPD0N+2HZ1HTw7QKRhk1pFHf3zj+MeGJ8aj513dgIAZjSfUcTe2uNk4YSVnVcielI0xjQYAyOREQ49PIT6v9XHkL1D8tSIP3n7RHGMjamNwcb0MaCqdV1ZDOhFIhEOf34YJ4eeRJdqXUp6OKWPrCwgRv43oE1AD3Cy+5Jyu5fJuIBeVYYeUF9H//Ytd+MoiYCezc7375+ncfmaNRSkOjvT91u3AjcjJRTpAprX0efmytP8KDxDD5Asavt2Kl949IiUA/r6vbIBfT5DvOxsktPXqkWKBHYxd9Ik+vPcurVwAYmDAwkKrl6l4D0wkOwAkpKoG1/duhTsr1vHb56gDUKGXgV37txBb7mZljLlypXD69ev9TIoAf3Rxr2Noj816yJbWnn89jFevn8JEyMTNK7UuKSH82lQvjwnFdu/Hz90JMfrI9FHVNfSs7K9hg0LlZ6HxYUpAtMNPTbA3Ngcg30Go2mlpkjPTse8M/MKHqSmjh4A6pavi4lNqM5/4tGJ/Nz489GtGxSt6/b9qkFALw/0pI/8cOcOScy2bNH/3Ohd5juMDiYX3UlNJqG9Z3tYmlhie+/tWNd1HSRiCf69+y+abmyKdVfXAaDe84UFn1Ip17qWDa55s2MHTSjr1aM3XRRKvehZvLzocKmUkh18YNvXnXys+cJNfqY1n4YdvXdAIpZg552d6PF3D6Rnp6vcV5P+8/lhA/prL64hR1qMOkItWXt5LXJluWjj3qZYPmsr21bGhp4bcO9/9zCg9gAwYLDzzk7U+KUGvjr0FV6kvRAM8ZRgM/RPU54q/p7KUg96ZWo41UDHKh1Lehilk+ho+vC0sSGtsjawsvunT7V3YNeFqCgKzM3N1adH1bWuY7PzLi7F37IuPZ36rgJ5zPCSk4FllJvAqlVUicYwwMyZANNCS2O8Z8/o92xqClSoUPT+jo602G5sTDf41auLPqYo4uNJ9i8WK5QU79/TqatWpXWDqCiq1Jw3jzop/vwz4K6hP2edOsCKFXS54GD60RobUyOGSZPoz7x/f+DwYVrn0AdZWcCDB7QtZOiVsLOzQ4IKueqNGzdQqVIlvQxKQL8sar8IErEEJ2JOKEyfSiNsdr6hS8NCW3AJ6Bn2ZrV3L6o7VUe98vXAgMHxmOMF9+VRP5+Zm4mxBymjO9Z3rKLfsFgkxuoudOPZcnMLIhIi8h6owulemYXtFqK8ZXk8TH6IVZdUyPZ5UKMdBfTvohLxjEc5ftL7JNxJugPzbODJvRl4JvEA8+EDRo0Chg6lsj99MfXYVMSnxsPLwQvLOi5TPC8SifC/Jv9DyIgQVLSuiPuv7yvUNoN9Bhd6zvPnaRXc3l5hl8APZTO8sWPzZCfUoiJDD3ALCf+p8UPMT5NKpNTQpZ+8MkPqDsGhwYdgaWyJEzEn0GFrhzyLVR9yPsB9lbui/l2T+nkWL0cv2JvZIzM3U6WcvDSRlpWG36//DgAIbK55CcuHD5RE8vBQNDTgjbejN3b124Xr466jS7UuyJXl4rfrv6Haz9Ww9PxSAEJADwAuVi4wk5hBykgRl0JmeGUxQy9QBGyAW7Mmv89gVZibAz170nZJyO7ZBfomTShyU4W6DH1JGuIdPUqRYLVqeWzRly6lysB69agSbelSqho4dQq4bqZlQM/K7d3d+Xv0NGlCKwoA8PXX2pvxsbD18w0aADY2uHmTbunTplHw7eJCbYDj4oDFizl1grYYGwM9epAI4sULzjwvO5vmCv7+QOXK9NZ0VUXev0+LA/b2BT0ZyxIaB/SDBg3CN998g8TERIhEIshkMoSHh2PGjBkYNmyYIcYooCNV7KtgnC85VM85PafE2tjJGBmORB/Bmktr8Nftv3Ai5gRuJNzA89TnyMrNUtTPC+3qihlWcRMaCrx6ha7VqD/9sUfHCu7LI6D/LvQ7RCVHoYJVBfz42Y95Xmvm2gyf+3wOBgymHZ+W92+RLb6KjlZphWprZosVnVYAIDd+1hmZL1KZFHCnPtsu4qe85jZnn5wFAIhe1oEH8wyuuXFYuICBkRHw118kVNBHS5bgqGBsvbUVYpEYfwb8CQtjiwL7tKjcAhHjIhRGUi0qt0A1h8JliKxiPiBA/VxKJZcvA5GRNBkcMoTfMcoBvdLvlQ3oT56k8sKiqF2uNgAgKjlKq17mquhcrTPODD8DR3NHXH1xFa22tFIESAzD4Gkq/S152nnC3U7zlmBikVixEFHa+9FvurEJKVkp8Hb0hr+3v8bHMwxN6uLitFep+Lr44uiQowgZEYIWlVsgIzdDsUjFys0/ZUQikWJhg5XdCwH9JwgbyWhjiKdMSbrdF1Y/z6Ic0CuPryQN8VhpW58+isWU2FiShQPkcC8WkzBtkrzj56S/moERiegemJjI/1pFOdyrY8IEkgjk5tLvWBcLeaX+8y9f0hpQUhLd1n//nd7SjBkkFtE3Tk7A5MlARATNp6ZOpecSE2kRoXZtqmYIK+gNzAtlub2262IfAxoH9EuXLkWNGjVQuXJlpKeno1atWmjTpg1atGiBefNUyGgFSgXz2syDucQcF+Mv4nC09rWp2pCWlYafL/8M77Xe6L6zO6Yen4ov9n2Bzjs6w/cPX7iucoXZd2bYGLERgFA/X+x4eNDSqEwGHDyoqGU8HnM8r5FYVhbnLKImoL/z8g6WhVN2eV3XdbAzsyuwzzK/ZTCXmCM0LhR77+/lXrC3527sarL0Q3yGoLVba3zI+YDpx/M6czMMgydvn+DAgwNYHLIYY4PHwn+nPxr+0RAuK11gssQEMyKpptql0n5e/dFZGTZi2ymemzkTOHeOVnqjo2kd4pdftJ8nJX9IxriDtOAW2DwQLSqrqTMEUN6qPE4OPYnd/Xfjn76FvwGZjCsB1Fhuz2bn+/fn2tEVhZsbzXAyM/NMZmrUoBtyTg4/2b2brRssjS2RLc3GozePNBy4eppUaoLwUeFws3XDw+SHaLGpBe68zOvG0869ndbn/xj60efKchXtHwObB5Z4J5E27m1wfuR5HBx8ED7lfCCCCK3dNOt/XFZRbl1X1nrQC/BEOUOvC507k+nss2e0WFucFOZwz1K9OkVab97kDUpLyhAvMxM4JO+00rev4ulvv6UMcocOQKdO3O5z59L05dJ9W7yp5ENPapKl5+NwrwqRCPjjD/r5PX9Oi+9KXYI0Ql4/n9OsNfr0oT8Vb2+Swo8bV6jpvV6pV4+EB8+fU3eeXr3I++fKFcraP3yo+TnZgL4sy+0BLQJ6ExMTbNiwATExMTh06BB27NiBBw8eYPv27TDSqMGxQHHiYu2CyU0nA6BaenWOz/rk8dvHmH58OlxXuWLKsSmIeRsDOzM79KnZBx08O8CnnA8qWFWARExOXQwY2JnZoY17myLOLKB32Cz93r1oUbkFbExt8PrDa85IUSqlIqqsLKq7V+HEKpVJMfbgWOTKchFQIwB9avYpsA9A9bQzW8wEQG3s8tTDF1JHD+Q1yNtzfw/mnp6LCYcnoNXmVrBdZosqP1dBwK4AfHvuW2y8sRGHow8jIiECiemJkDEyJFnT8qyL9A2uPY9QzBfUoSqgB4BWrWgluUcP+pFMnEhBM58MdH7+d+R/ePn+JWo518Ki9ouK3F8ilqBfrX6obFu50P0uXKC42taWut3wJjUVitUOPmZ4LCYmpJEDuAmKHE1k92KRGDWdaQJ7N0m/rVCrO1XHhVEXUKdcHSSkJ6D1ltYIf8pNvNp5ttP63B9DQL/n3h7EpcTB2cK51LQIE4lE8Pf2x83xN/Fq5it0rta5pIdUKlBuXcf2oHeycCozPegFeKCvDH1Jye7fvOEWJQrL0Jubc3MKZX01m6Evbsn9qVNUQ+/qqkhe3LpFtjIAZeeVM7329nKnewAH32ghu+frcK8Ka2taubewIBnc4sWanyM5mWzqAczY3woXLtC8ITiY/3q+vjExIWXh/v0U3LdsSVOTgADNSx3ZPFRZNsQDtAjoz5+nOmc3Nzd069YNAwYMgFdJ1LcIaMzXLb+Graktbr+8jV2RuwxyDYZhEBIbgt67eqPaz9Ww6tIqpGalorpjdazvvh7x0+KxZ8AenB52Gre/uo2EwARkz8vGm6/fIGpiFB5Pfgx7c3uDjE2gENg6+pMnYfwhU2FSdOzRMUo9jx8P7NxJS6WbNqnULf1y9Rdcfn4ZNqY2WNd1XaFmbV+3/BoVrSviybsnWHN5DfdCEQE9APiU91EsTi09vxTrr61H+LNwpGWnwcTIBA0qNMCwesOwqN0ibOixAYcGH0LEuAgkBCbgv8l0k62QDsB3A3YV8m8Q+y6WjLqkEhi9KKgacXSk/uqrVnHeNA0aaJYA+ffuv9h1dxeMREbYFrBNr94RbPDcsyd57fBm504qjq5ZkzNM5IuaOvr+/enx+HG6KRdFbWeS3attn6gDlWwqIXREKFpWbomUrBT0/Ken4rU2btovJrKS++g30Uj+oN6qN1eWi1OPT2ndlk9bGIbB8gvLAQATm0yEubFh2y9qilgkhqOFY0kPo9Sg3LpOkNt/guTmculIXTP0QMnI7tnOV97epKEuDFV19CWVoWfl9r17K2raZ8+mH9vAgaoFihMm0O3v5AcdAnpNM/QstWsDv5EJMRYt4sz8+CKP65LL18LPfztDLKZ1n+rVtRuOvilXjuYzFSvS+tDw4aRA5APDCBl6tXTo0AGenp6YM2cO7hmyf5OA3nEwd1BkRuefna9XN+bM3Ez8efNP+P7hi3Zb22H/g/1gwKBz1c44OuQo7v3vHsY3Gq8yuyASiWBvbg9vR28hmC8patWiVfDsbODIEXSpSrL7o9FHqKBp40a6se3cCXTvXuDwpPdJd4CZ7gAAIABJREFUmHN6DgDgh44/oJJN4QaZliaW+N7vewDAktAleJn+kl5gV/GvXqWxqCGoXRB61+iNLtW64JuW32Bnn52I/CoS6bPTEfFlBLYGbMX8tvMxxncMunt3RwOXBqhgVQFGFcgUz/kDAJ8d+Gu3asdzADjz5AxtPG+CDi1V92AXiejHc+EC3cxjYyl7v2JF0Tecl+kvMeHwBADA3NZz0bBiw8IP0ABluT0bTPNGEzO8sDCq4TtLXgPqAvpatUh6n53NKRkLgw3o777Sb4aexd7cHieHnkTP6j2RJeUUIs6W2jv9OJg7wNvRGwBw5bl6N+kJhyfgs+2focKKCmi9pTVWXliZpz2ZoQiNC8X1hOswk5jhq0ZfGfx6Arqh3LpOCOg/QZ48IfmXubnmVuKq6NyZVp7j48nxvjjgUz/Pwgb0bEb/3TuA7ZxVnAF9bi6t1AOKRMfZs+SRJ5EAS5aoPszUFPj+eyAcFNAzERH8XUPlirYsFw9MmADMmsXF+LwZOhT48kuKYIcMAS/XXxa53P6/l1TutHJl3pKC0kCFCjSnMTEhKf6yZUUfA5BK8fVrmr7Wrm3YMZY0Ggf0L168QGBgIEJCQlCnTh3Ur18fy5cvRzzbQ1GgVDOl2RSUsyyHmLcx2HJzi87nS0xPRNC5ILivdsfIAyNxM/EmzCXmGN9wPO5NuIdjXxxDl2pdSrxWU6AIRCIuS79vH7p6kTGe//bL1JsEADZvVhsdbr25Fe9z3qNBhQYY13Acr0t+UfcLNKrYCGnZaZh/Vq5X8/ampqWZmYW6zdmY2mDvwL04OuQolnVchsE+g1G7XG0YGxXh/Ca3ZjXPBaxE6bgv/heRaszUFXL7Jx2golNnHho1IkOXAQNoPjBzJtV7qfOoYRgG4w6NQ3JGMupXqI+5bfTbUvLyZZq3WVsDn32mwYEREfRlYkITBHU8fUqBfJs2wK5dNJMB1Ab0IpFmsnvWGM9QAT0AmBubY8+APRhWV39mrkXJ7o89OoYNEbRgwoDB+afnMePkDFRbWw0+630w/8x8XH9x3SDGpSsukqHkiHojdFq4ECge2Az947eP8eQdTfg9bD1KcEQCxQob2FavDuijnNXMjMv0sylLQ8Onfp4lf4aezc5XqED1/8VFSAiVCjg7A61bg2GAb76hl778svC1hf79gQpN3PEcFSHKzaXERFFkZ5OmHMD+W55Yv54k/VWrkrz8zBkNBBWrVwO+viShHzCg0KSIMhknKKAPQRuMGgVMmcLzesUM61cEUOu8I0eKPob9U/f2prWxsozGUZaTkxMmTpyI8PBwxMTEoH///ti6dSs8PDzQQaO+SAIlgZWJFea2puBhYchCZORkaHWeiIQIDN8/HO6r3bEwZCGS3ifB1cYVy/yWIX56PNb7r1fUwQp8JLAB/eHDcDVxwqqI8pgbKn/tl19I56QChmGw8QYZGn7V6CveizdikRirO5NB18aIjbiZeDNPD1R1xng6YWmp6Gdb7j2Ahn+olN0zDIOT0ZShF8f5obu/iCYctWqpzVrb2lLp+e+/09zp6FGgfn2aH+Rn++3tCI4KhrHYGNsCtsHEyERf7xAAFzT36KGhmQ2bne/TR7VE8sMHYOFCSrcr/+DYyZeagB7gAvqjR6k8sTBqOdPkLup1lEH7ukvEEqz3Xw8vBy/Ucq5VaJkIH5pVkgf0zwsG9O8y32FM8BgAwJSmUxA3NQ5ru66Fn6cfjERGiEyKxJKwJWi0oRHcV7tj0pFJOP34tF7e/4PXD3Do4SGIIMK05tN0Opeo6H8FAT3gYecBEUR4n/Ne0TlByNB/QujLEE8ZVnN8uxhaa+bkcPVnfAJ69n3mD+hLSm7fqxdgZIQ9eygut7Tk6uTVIRIBK38SKbL0L/fykN0/e0YRu5kZth0rB4CsaGQyEgr4+QE+PjSveP++iHOZmdHN386Oyh2+/rrIy799mgbjyBsAgMxGrfHrr6X7c33MGE6I8PnnKNIH6VOR2wMAGB3Jzc1lDh48yNSvX58Ri8W6nq7UkZKSwgBgUlJSSnooeiMzJ5NxW+XGIAjMivAVvI/LleYye+/tZdpsacMgCIqv5hubM7sidzHZudkGHLWAwZFKGaZSJYYBGKZvX3oEmL+H+RZ6WGhsKIMgMJbfWTKpmakaX3bg7oEMgsC0+7MdI5PJGOa77+jaAwZo+04Kx9OTYQCm5WgjBkFgKje6xchkeXeJfBlJf99zzZkOn2VqfInbtxmmRg16G2IxwyxcyDC5ufTas5RnjO33tgyCwCwNXaqHN5QXmYxh3Nzo2nv3anBgWhrDWFvTgWfOFDzprl3ciQGGad2aYY4c4d5kVhbDXLpE31eqpHJc1arRy//8U/hQpDIpY/mdJYMgMPdf3dfgTZQsES8iGASBsVtmx0hl0jyvDds3jEEQGK+fvZj32e/zvJb8IZnZfms703dXX8biO4s8n692y+yYL/Z+wfx39z8mLStNq3GNDR7LIAhMwD8BWr83geKHvU8bLaTPqkNRh0p6SALFxbBh9GG5eLH+zrliBZ2zXz/9nVMda9bQtZydaW5RFKmp3L3lzRuGWbSItkeONPxYWaRSRlrBhWEA5tw3R5hFi7hb3oIF/E+zqe5qhgGYK+W6Fb3zyZMMAzC53jUYY2O61r179DVhAsNYWnI/Fjs7hgkMZJjHj4s454ED3EH//qt2t6wshpnle5xhACbOyIN5+ZL/eyxJMjMZpnlzenu1a9PURR2ff077ffdd8Y1P3/CNQ7XWQYeHh2PChAlwcXHB559/jjp16uDw4eJthyagHaYSUwS1DQIAfH/+e6RmFe5SlZKZgp8u/oRqa6uhz799EBoXColYgs99PsflMZdxYfQFDKg9oGi5s0DpRizm3O7lBdgL2wJTfZ4X2hWBzc4PqjMI1qaqa80L44eOP8DUyBTnYs/hQNQBXsZ4OlGOVsG72ZCJ2TPnDYiIyLuLQm7/tBUG9NXEUY7w8QGuXQNGjKCV9gULSPr+4gWDMcFjkJKVgiaVmmBmy5m6vBOVXLtGinhLS6BLFw0O/Pdfso+tVg1o1457/uZN+n7gQDpx5cqUnQ8JoQtYWtKbjI3lMvTPn1PZhBIiEVexUZTsXiwSK7L0+na6NyQ+5X1gLjHHu8x3eJjM9dcJjgrGtlvbIBaJ8WfAn7AwtshznIO5A76o+wX+G/AfXs98jYODD2J0g9FwtnDGu8x32HF7B/rt7genH53Q4+8e2BSxibep3sv0l9h2axsAYEbzGfp7swIGh62jlzLUikrI0H9CGCJDz9p8G1py//Ill85evFhhLFco1tZcl5T79w2aoc/KIiHA/v3U53zsWKBtW6BHucsQJyYgBTbo9EMHfPst3fLKlwcCA/mf328+zWGqJl3E09gizHTkxfIJZp7IyQHq1KFfec2aJIx8/pyMd6tWJVuBlStpu1cvMuNXKcfv2ZOrExg9WmWvt6QkoGNHwCKCmrtbdW3DTo1KPaamNIeoUIHM+UeOVF+W8Cll6DUO6GfPng1PT0906NABT58+xZo1a5CYmIjt27eji0azR4GSZGi9oajhVAPJGclYeWEl3me/R2J6Ih69eYQbCTcQFheGI9FHMPnoZLiuckXgiUDEvouFo7kj5rSag9gpsfirz18KZ2eBMoJSsbh02lQs/8wCL9+/JDm8Ct5lvsPuu7sBAGN8x2h1SXc7d8xoQYHGjBMzkNWgLtUMxsdrZuzCF/ldq5ej/G+37g5s/ydv6cmhu3JDvCd+CAjQ7jKWlsCWLcC2bbR99ixQ/fMNOB5zHGYSM2wN2Kpo2ahP2GDZ31/DmjFWbj9mDEXfr15Rd4OGDck0x8yMViYePKD6PJGIvqpS0IFHj0imz9Y7qnD1YWX3R44ULR8sjjp6fSMRS9CoIlkgs3X0yR+SMe4g+UoENg9Ei8qFy0/Njc3h7+2PjT03IiEwAWEjwxDYPBBV7KsgS5qFQw8PYczBMSpN9bJys3D9xXVsuL4B4w+NR5MNTeC+2h1Z0iw0rdS0yGsLlC7YgJ7F3U7oQf9JkJPDBfS6tqxTho1qHj3iod/WgVmzqJ1Jw4Z0P+GLsuyebVmnZUCfmwvExADHjpEN0KRJ5Avo6Un3xdq1abrz9dfk+RsaCrRNpkTGSdMeaNzSFCNHAkuXkuTeWoNchXuv+sgUm8MBb3FoZVThO8vvk7feeQAoaFNka0vGuw8fkqFs584UvAYHU5KgTh1g/XoVZWxLlpDHTVoa3XiVDPpu3gQaNyZP2/ZGVFfpEPBxtYuuWJHmOsbG9Ni+PVUDnjrFtbXLyqLpClD2W9YBgMazydDQUMycORMDBgyAU1FtKARKLRKxBIvbL0b/3f2xKHQRFoUW3v+6tnNtTG02FUN8hpS6dkcCeqRdO3JEcXaG0Zw58Nv1GMFRwTgafRS+Lr4Fdv/7zt/IyM1AbefaaFqpqdaXndVqFjbd2ISYtzFYe3czZtSvD1y/Tln6gQN1eEMqkAf0NRknOBu74xXisD3kP/wkGwqxmNqKhT07BwBoYNcB5cuDboaNG9PxV69Sz1eeDB0KNGkCBIx4ggctaJm/RcZSVLWtoc93BYBu9LtpfUURPPPizh2quZNIyCF3zRogKIhSAgD9Dn78EXBzK3hstWpUkxkTQwF+lSr0/ePHVGuvRIMGNKF68oRq6Qsbo6Gd7lk+5HxA4w30u7069mqB7LmmNHNthrCnYbgUfwkj6o/ApKOT8PL9S9R0qolF7Qv/nM2PkdgIrdxaoZVbKyz/bDkikyKx/8F+7I/aj4iECJx/el5hrFfZpjIS0hOQK8stcB4Hcwcs9Vuqs0cAoNO/goCGsMZ4APWgtzIpRnMwgZJjzx6K0MqV028P9nLlKK2ZmAhERgJNtb9nq+XiReDPP2l73TrNDP1q1QJOnKCAns3Q83z/DEOecGfP0lpATAyti6jDxoaM0ry86NHbi0Gfr/cCL4B+O/ugXx/+wy6AsTFSvJvA7EEInv4dDtmamupFCnKH+/PxHgDUd6URi6nBUPfuQFQU/Wj//JN+VBMmUFu9UaOA//1PvsYukZCpT4MGdH+vUgWoWhVPmco4e7Uyeua6QebiihbJlwEpgNatdXjDJUPLlvRz+PJLEgyyfkViMQXwNWoAUilgbw+4upbsWIsDjQP6cE16KwqUavrU7IM27m0QGkcrdCKIYGViBSsTK1ibWsPaxBoedh4Y32g8/Dz99DIZFCjliMV0V5TTtVpXBEcF41jMMZVO7KzcfozvGJ3+PqxMrPC93/cYeWAkFocuxoRG/WBh4IBe/OoVJvQag4Vh8/HG4w9cvDgULVuS4WMmUoAMO4zoJF/EYBjOrEcLB3Ivbxmcx47Eg2fpQGwbnNk6BW3PAH//rZ+ORCzXr9P8wNwc6NpVgwPZ7HyzZtSvhs0O1a9PwX2bQlbv2QyKsjHe7duKiYoyrNv98uW0ql5YQM9K7g3Ri14ZhmEU12D04C7POt1ffn4Ze+7twd+Rf8NIZIStAVthJtHEoTAvIpEIPuV94FPeB/PbzsfTlKc48OAA9kftR0hsCJ6lkprFwdwBvi6+aOjSEL4uvvB18UUV+yp66zSi47+CgAYoZ+gFuf0nAsOQrhqg6EyiZxVX3boU0N+6pf+AXiqlMQMUXTZrptnxrBrh0iWuRQzPDP2lS8D06XmfMzOjw/ME7vLtcuXymb/dvAW8kN88O3fWbNwqcOjREngQAu/kCzh3bgzUeobLM/SPZJ4KuX1RVK8OrF1LSfitW2n70SOS5q9eTUH/5MlAx44uEP3zD7njvnwJvHwJNwAKW9QE+WP58vpdOCpGxo2jtYizZ4HwcPqKiyMVAtsoqV690m30py94fVIEBweja9euMDY2RnBwcKH79uzZUy8DEzA8YpEYZ4efxav3r2BlYgVzY3OhvZxAHrpUozKai88u4l3mO9iZ2Slei0iIQERCBEyMTPBF3S90vtawesOw9spaRCREYKd1HMYAhnG6ZwvFkpIwttHXWBQaBMb9PH7dfR8tW9bEvpvy+vnYdug3WQ/tggCsu7IOYc9CYGlsiR87bcGcfWJcvEiL51u2UD2cPvjpJ3rs2VNh5l80GRlcRuX8eXp0cgK++47q74rKsChL7oFCne4BykAsX07ywYwM9WUBbIaedbr/WDw6WKXK7Ze3Mf7weACkQGlcqbFer+Nm64ZJTSdhUtNJeJPxBjcSbqCaQzW42boJi69lBOUMvRDQfyKEh5MRiqkp8NVX+j9/vXqUBTdEHf0ffwA3bpDLOt9G4cooB/QABZo8te5y2x/4+ZHi39ubsrJ8yvcBcO72rC+Mjhi3bQEsB1rgApZsRpEBfSw81Gbn1WFrS4H7xInA8eNUWnDsGN1bDx2iDPWkSe3Q+8ozrBwXhdjzz+CGpwjwfYbWHs8gevaUAv3Jkz/qiJf1HJgwgb5//pxyQRcuUG5CE/+Djxo+DnsikYh5Kbc/FIlEar8El3sBgbJHjXU1GASB+Tcyr1vqhEMTGASBGbh7oN6uxTrme0wTkTWpRMIw798XfaAm/PUXnbtDB4ZhGKbZ6p4MgsCYB0xjcnIYxnuJH4MgMFUGreWOSU/nXGPT0zW6XNTrKMZ8iTmDIDC/XvmVYRhyqW3ShDvl5Mnk3KoLUVFkNg8wTEQEz4NSUxnG358biETCMFOnMszbt/wvfPo0HVu9On2/bh19H6DaUV3ZhX/fPvWnlclkjNVSKwZBYO4l3eM/Hg1Jz0pXOMqnZ2n2u1WH60+uinP6/OrDZObo+MstRejwryCgIe8y3in+jmYcn1HSwxEoDnr3pn+usWMNc/4dO+j8rVrp97yvXjGMvT2de+3aovdXRXIy9+ECMEzLlrwOk8kUzWuYPXu0uzRTqxadYPt2LU+Qj9evFe+jkukr1bfUjAzFPk5IYu7p4TYXFcUwkyZxDWuUv0xNGWbrVt2vIVC86NXlXiaToZw8qyWTydR+SaVSAy49CAgIlARdq5F2+9ijY4rnPuR8wF93/gKgvRmeKlq7t0b/Wv0Ra8PgtZ0pOdtcu6a38wPIk6EHgFmdyLAsw3sbDp9OwaMsKisa0MhP50tJZVKM2D8CGbkZ+KzKZxjfiDK2np5kSMOuHP/8M5n7F9VTtTCWLiWzeX9/yvwXikxGWj1vb1rKB7ha+FWrKMPCF1YS+fgxSS6LyNCzsnuAVtR371Yt3RaJRJzT/UdkjAdwsnuJWIJtvbfBVKJ5pwQBAVszWziaOwIQMvSfBDExZL0OkBOaIWDdwW7f1m/NzOzZwNu3pAAYP167czg4UFaehafc/uZNrtRMK7X8gwdUR2RsTDdQfeDoCEbuIdMg6yL++UfFPk+fAgDSYYnytZz00tDA25vmE/Hx9OjtTc+7uJDx37Bhul9DoHSisb5627ZtyMrKKvB8dnY2tm3bppdBCQgIlB5Y2f2xmGOKGuM99/YgJSsFHnYe6OCpTkumHT90/AEmEhOcrSj/nNF3+zpnZ3qUB/T+1bvAUuoKWCRj8sGvITPKBNJcML6f7qZ1Ky+uxMX4i7AxtcGmnpvySKFNTIAVKyiednQEIiIAX1+ovvEXwePHwI4dtD1vXhE7X74MNG9OPfUSE+k5kYiK0LSZUVSqRG8mJ4e6Enh6coNSM2GcNo3magkJZJjfvbvKkvtiq6PXNwNqDYAIInzv9z3qV6hf0sMR+IjxKe8DgOv6IFCGWbOGPjO7dtWvu70yNWrQ53VqqspOJFpx5QqwaRNt//KLbnX/yu+bZ123zmr5ffvo0c9Ps8XsIhC1bAmAZPebN6vYQUluP2CgfiXvNjbk7H//PlUwREaSOa9A2UXjgH7kyJFISUkp8HxaWhpGjhypl0EJCAiUHtq4t4GFsQVepL3AnaQ7ADgzvNENRuvdd8HT3hPTm03HBXlLWln4eb2eX5Ghf/0akEphJDZCX8/RAICnzn8AABxTO8DdXbcbbGRSJOafpV68a7qsQWXbyir3696dMgytW1O7lcGDqS+uUpeZIvnhB0qOf/ZZIT5HubmcUdGVK9RejnW29ffX3gbWyIjLyj96BHh40HZ6Ov2MVeDqSgmi+fMpKXL0KLURWrYMyM7m9isup3t90792f7yf817RjlFAQFu29NqC3f13o61725IeioAhefsWiqgvv7ubPjE25oLm27d1P59MRkZ4DEPpX3kQqzXKAT3PDD0b0Pftq+U12RP00cXaXgUtqE1oS9EFXL1KZvPKfLhLq9ja1M/zRSymOYGDg2HOL1B60HgmzjCMSsOd+Ph42Nra6mVQAgICpQcziRnae7QHAByNPoqHyQ8RGhcKsUiMkfUNs4g3u/VsRHnZAwCyws7pVxrIttuUyYA3bwAAQb1GAQz3udbBM5/cXiQiO3p3d17mMTnSHAzfPxzZ0mz4e/tjeL3hhe7v6gqcOUMBrkhEfXGbNOF6qBbGs2dkrAfQ8WrZvZvbceRIWrJn3ezHji36QoXBTrxiYshauFIl+l6N7B4geeSiRTSnbNeODPJmzyaVAuvNpwjokwwX0ItEIrjbusPd1l2vZnJltb2nhv8KAjriYeeBfrX6CUaHZZ0NG6g3vI8PZYoNCSu714cx3qZNVBZnY0Mry7qirBLjkaFXVst3767F9eLiaPxisf7caVnkAX1T0RVIkFMgSx9zOhYAkOLgqRe5vcCnDe+AvkGDBvD19YVIJIKfnx98fX0VX/Xq1UPr1q3RsWNHQ45VQECghGBl90cfHcWmCJLWdfPqhko2lQxyPRtTG/QfshSZRoB5ynu8uX1Ffyc3NuaWq+Wye08HN3jkcH3eJvvnm1BZWJA8LjaWV+PtpWFLEZEQAXsze/zh/wevybhEQgHuyZPUKvjuXQp0VUnRlfnxR1K7t21bRCtZNhszbhxlgi5fpgx6xYoa9rhTgYZO98rUqEGLGdu20VrL3bv0PjZv5mTGD5MfIkdaSFNhHbAwtkDs1FjETo3VuQf9p4CG/woCAgJFkZNDBc8AZecNvXhTrx496hrQv3lDq7AAsHAh3bh0RTlDX7Wq+v3ksMl1rdXyrNy+dWtOvacvvL0BBweYyjLRADewfXteBdqbG7EAAOdGHvq9rsAnCe+APiAgAL169QLDMOjcuTN69eql+Bo0aBB+//137GCLOAUEBMoUrDFe+LNwbL5Jy8xjGujPDE8Vw5qMxX0PKog7tHWOfk+ezxgPAKa0+hIAYPG+Jlr5uGl96oiECCwJWwIA+LX7r3CxdtHoeD8/kuDXq0cdZTp3VqtcR0IC10K+0Ow8AERF0WNteS3uH1RegNGjde91rKoXPcAroAdo/jp0KA3x88/pubVrgco2lWFlYoUcWQ4evdHBMVBAQECgtLJ7N/XaKl+eaq4MDRvQ6yq5nzsXSE4G6tSh3mn6oEED6sdWty49FoHOanlDye0ByvrLs/RdbS4gORk4eJBeevcOMEug1fqaXT30f22BTw7es7gFCxYAADw8PDBw4ECYmZkZbFACAgKli6oOVeHl4IXoN9F4/eE1KlhVQDevbga9ppHYCI5+/kDMLmSGnkFkUiTqlKujn5OXK0daPeWAvksPGJn8iyae2ptPZeVmYfj+4ciV5aJfrX4YWHugVucpXx44coS866KjqcT9zJmCGdEVK4CsLNpPbZ9bFla/X706SeNPn6ZIevRorcaYBx0DehYHB2D1amDnTlrUSEoip/srz6/g7qu7qOks6BIFBATKEAwDrFxJ2xMnUv95Q8NK7mNiyOvEykrzc0REAL//Ttvr1um+KMxiZ0f3DR4xRlwccP26Dmr5ly+5+q7evbU4AQ9atAAOHUK/ihewKHUqNm+mWv8DB4DOTCwAoHIbT8NcW+CTQuMa+uHDhwvBvIDAJwgruweAEfVGwNjI2ODXdOs6CADQ/Bkw/fh0hct+oWRnU9sctl5cFSoy9CKRCJP8+qNpFRXuwhkZQOPG9JWRofa0QeeCEJkUiXKW5fBrt191qnutWBE4dgywtyd1/KBB5GvH8uoV8NtvtM3W3qslN5cLtmvU4ByJO3WiYmhdYaWRMTE0QWUD+qLqBVTg7Ex19ACVHxi6jj4jJwONNzRG4w2NkZGj/ncrQPD8VxAQEOBDWBgFx2Zm2rd70xRnZ+pjxjAFndr4oGyEN3gw1XvpEwcHXvU8bHJda7X8/v30Hho3BiqrNq3VGXmGvuabcAAMjh0jMcaBfzJQAS9pH9ZIVkBABzQO6KVSKVasWIEmTZqgQoUKcHBwyPMlICBQNmFl9wAwqsGo4rlo8+YAgNqvgCt3T+JI9JGijzl0iDIHX36pPkOsIqAvFJmMjHOuXaNtFVyKv4QfL/wIAPjd/3c4WzrzO3ch1KxJEj0zM3qcMIHzB1y1ipzwGzWidj2F8uQJ1Wmam1OdI7vYoasZHou7O7ndZ2RQHYCWGXoWtpfw8eOGd7qXMTJce3EN115cg4xR/bsV4ODxryAgIMCXn36ix+HDOcPW4kAX2f3WrdQLzcqKZGIlhN7k9lrb4/OgcWNAIoEk6QX6NX4KmYzsEh6digUASC2tadVeQEBHNA7oFy5ciJ9++gkDBw5ESkoKpk+fjj59+kAsFiMoKMgAQxQQECgN+FXxw6A6gzCn1Rx4OfLrD6sz5csDVatCzABNnwPTT0wv2hzt1Cl6zMkB5KVCBdA0oC+CDzkfMHz/cMgYGb6o+wUCagTo5bwAdQH6+2+SFW7YACxeTF5E69bR6/Pm8fBQYuvnvb2pR1xiIv0MevTQzyBNTLhM/6NHXED/7FleFyCedOpEjydPAjWcSDHxsbWuExAQECiU6GggOJi2p04t3mtra4z39i3wzTe0vWABSclKgMREIDyctrVSy799S3VsWp+AJxYW5AsAYKLvBQC0BlIpNxYAYFTVU2gXIqAXNA7o//rrL2zYsAGBgYGQSCQYPHgwNm7ciG+//RaXLl0yxBgFBARKASZEhOA/AAAgAElEQVRGJvi779/4zu+74r2wPEv/WaIFHiY/xK9Xfy18/5Mnue2//lItKWQD+lev9DLEuafn4mHyQ1S0roifu/ysl3MqExDABfALFlAcnpZGpZA9e/I4gXL9PGuGN3IkBeL6Qll2X748qQFkMuDpU41P1aIFYGlJJY5GyYZ3uhcQEBAodtasIclV9+5UClWcaNu6bsECum/WqAFMnqz/cfHkwAH60TVpoqVa/tAhKkWrU4cWug2JXHbfAhdgZUW3RQ/E0muC3F5AT2gc0CcmJsLHxwcAYGVlhZSUFACAv78/Dh8+rN/RCQgICMhvhoPSKAMcFBKE5A/JqveNjaUMsZER6dAZhlLY+dFjhj4kNgSrL68GAGzquQn25oaRz331FTBHbvZ/gRb6+WXnAS5D7+JChfkAMEbPXQqUjfFEIsBTbvSjhezexARo3562b4VWhrWJNXJluYh+E62nwQoICAiUIG/ecKVP06cX//WVJfd8a2du3QJ++YW2163T74KwhuzZQ4+l0t0+P/I5jPGVcAwiWyB4Qu4vIwT0AnpC44De1dUVCQkJAICqVavixIkTAICrV6/CtDjcOQUEBD4t5DfDSvfiUd/ZB+8y32FhyELV+7Jy+2bNqMhcLCZJ48WLeffTU0Cfnp2OkQdGAgDG+o7NYxxoCJYsAYYNo+2aNTUo/WMz9M+e0SJH+/ZcAK4v9OR0z8LJ7snpHjCcMZ6AgIBAsfLHH2SCUq8et3rJA6mUrE/GjNHRw6J6dQrI09NpIbwoGIZc+GUyoH9/6q9aQrx5A5w9S9taqeXT07mFbUPWz7PI5zC4dQtfDU2HkRHgax9Lz3kKDvcC+kHjgL537944ffo0AGDSpEmYP38+vLy8MGzYMIwaVUxGWQICAp8OdeoAVlYQpaXhN49JAIBfr/6K+6/uF9yXldt37EiSwBEj6Ps5czg3OUBvAf3MEzPx5N0TuNu6Y2WnlTqdiw8iEbBxI/Dnn7ROIeb7Cc5m6NkWPfoyw1PGQAF9WBjgbS/U0QsICJQRsrOBtWtpe/p0jWqo166le8CmTUBoqA5jkEiA2vIWrXxk9zt20P3DwoJrs1dC6KyWP3YMyMykMjG54tiguLoCbm6ATAbf3Cu4fRto6xFLrwkZegE9oXFAv2zZMsyR6z4HDhyI0NBQfPXVV/jvv/+wbNkyvQ9QQEDgE8fIiDLuAJo+laJX9V6QMlIEngjMu59MRr3VAeCzz+hxwQLKQpw7l7e2ng3oU1KokTsfnJzyuBCfiDmB365T37gtvbbA2tRa03emFcbGZIjMO8H+5g3nFZCUBDg6GsYESF3rOlYdoCHe3uSzl50NmKbQxPPeq3v6GGkBnCyc4GRRjA7THzn5/hUEBAQ04d9/gRcvqASK1WDz4PFjYO5c7nu2+6jW8DXGS00FZs6k7XnzDNfijSc6m9Mry+2Ly5COzdJfuIBatQDjZ4LkXkC/aBzQ56d58+aYPn06eujLLVlAQEAgP0o3w+WfLYex2BhHHx3F0eij3D43bwLJyYC1NTnlALQqPmECbStn6e3sKEMB8DPGs7Sk/V69Aiwt8S7zHUYHjwYATGoyCe09+Usmix02O29nR48dOlAfPH3DBvApKfR7kJsZIiSE0ikaIhJxWfrX9w3Xus7SxBKvZr7Cq5mvYGliqffzlzXy/SsICAhoAsNwreomTuRdh84wJKz68AHwkjeZ+e8/4N07HcbCt3VdUBA5lHp5lUy9vxLp6dTOFNCy/D0ri1L8Wp9AS9g5THg4vYnXr+l7IaAX0BMSPjsFs201eNCTl+WygICAgAYoBfRejl6Y3HQyVl5ciYH/DcS0ZtMwrfk02LH18+3aURqbZc4c0ihev05OOv36UbRYrhxlSZKSSBKnAVOPTUV8ajyqOVTD937f6+c9Ggo2Q25tTbM/Q00gzM3p5xgfT7L7xo2pv+7bt8CVK9zvUAM6daJWfXfP1gZ6kNN9tjQbJkYlZ8YkICAgoDUhIcCNG/R5+eWXvA/buJG6rJmbU+fRgAAgMhLYuZNbs9YYPhn6yEhqnA6Q3r+EvbKOHtVRLX/qFLWIqVSJW/gvDtj738WLwBN5dt7OjltoFxDQEV4BfUAAv57KIpEIUqlUpwEJCAgIFKBpU3qMiQGSkjC/zXyEPwvHpfhLWBS6CD9f+RkR/znCE6D6eWWcnSmrsGgRyQUDAig7rxzQa0BwVDC23toKsUiMrQFbS39Wl83Qs4oEtl+8IahalQL6mBgqk+jYEdi9GzhxQquA3s+PfAKir7vCqo810nPSEJ0cjdrlahtg8AICAgIGhs3OjxhB5U88iI8HZsyg7SVL6GN29Ghg2jSS3Wsd0LOt6x4/Jlm9jU3e11kjPKmU7pudO2t5If2hs1qePUHv3hqY0OiBevXIfyAlBThyhJ4TsvMCeoTXX7NMJuP1JQTzAgICBsHOjjPwuXgRtma2CB8Vjj0D9qCWcy1kpr2Dy40YAMCfzs+RkZOR9/jAQJo8RUUB27bRc5oY42VkAO3aIadNS0zeS4Zygc0D0aKy5kFqscNm6HPkPdwNGdDnN8ZjNfPybiiaYm/PJlFEKCciYzx919Fn5GSg3Z/t0O7PdgX/bgQKIP9XQLt2tC0gIMCThw+Bgwdpe+pUXocwDLUsTU2lde0pU+j5L74gtX5EBFWbaYWjI2WqAcrE52fXLlIUmJlR15gSJjNTR7V8bi41sNf6BDogkXCJiZ076VFwuBfQI8W4PCUgICCgA0qyewAQi8ToU7MPbo+/jUPus2EmBeKtgZFRP6Lqz1VxMOogd6yNDdfEPSiIZgaaBPQyGRASAuOwC3iVnoRazrWwqP0i/b03Q8Jm6FNS6LE4A3rWnPDyZa2LPdk1ASbJMHX0MkaGkLgQhMSFQMbo0gfq00D+r4CQEB3bZgkIfGqsXk2PPXrwtmf/5x8KYo2NKRtvZETPOzlR0hzQ0RxPnew+LY0WwgG6d5aCbPK5c1R+XrGilmr5sDDyd3F0BFq31vfwioadw7CeBaXgZypQduAluVdm0aLCJ7Hffvut1oMREBAQUEuLFlRQLQ/oWYzERvCLocgio10LuNs9R1xKHIbtH4aEwASYSeQGcBMmUJbh2TNg/XqtW9cZicTYFrCNO29pJieHC67T0ujR0JJ7gLumuzv1O46KogJQLbIinTtTtUTindpAa6F1nYCAwEdIcjL1GwV4G8u9egVMnkzb8+dzIjWW0aPJMH/HDuDHH6m+XmPq1iUJeP6AfvFiKkmrUoVzuC9h2Oy8v7+Wavk9e+iRLbsrbvKXnQkBvYAe0fgvet++fXm+z8nJwZMnTyCRSFC1alUhoBcQEDAM7M3w6lXqZabsDixvSec1cAKiBvaD11ovPEt9huCoYAyoPYD2MTMDvv0WGDeOFgaGD6fneQT0yR+SwVY7zmwxEw0rNtTTmzIwT56QzNDcnPTRdnYF6yT1CZuhj4nhnuvUiQL6Eye0CuibNAFsbYGUuFoU0CcJAb2AgMBHxu+/02dwgwZA27a8Dpk8mczQ69YFZs0q+HrHjtTI5elTYN8+4PPPtRiXqgz9/fucxH7NGsN0RdEQhskb0GuMTEY/JKD45fYsbOcXFkFyL6BHNF7junHjRp6vyMhIJCQkwM/PD9OmTTPEGAUEBASoZY6jI7WduXGDe/71a+57Pz+YSkwxtO5QAMDWW1vznsPPjx4fPyazPIBXQH8g6oBi+5tW32j9Foodtn7exYUeDZmdB7gM/atXnMSf1cwfP861DdQAiUT+a5NL7qPfRCNbmq2HwQoICAgUA1lZ5BAPUHaeh5tbcDDJ7Y2MgM2b8zZuYRGLgZEjaVtr2T0b0N+5Q0Evw9BKQm4uRc5aRc/65+5dIC6O1hbY27hGXLlCigNray1PoAfs7YFatbjvhQy9gB7RSw29jY0NFi5ciPnz5+vjdAICAgIFEYkK1NEDICk3w1APmwoVAADD6g0DABx/dByJ6Yncvq6udJ6sLC7DzyOgP/7ouGL7o2qZxtbPOzjQo6EnEDY23EIJm6Vn2wjGxubN3GtAp04AUl1hlGuDXFkuopOj9TFanWAYWkvSYo1CQEDgU2LXLiAxkYq/Bwwocvdbt4AxY2h7xgygYSGCsJEj6ZZ25gytU2uMlxe1onv/nk6wZw+1djM15Wr+SwGsl2CHDmQWrzGsu72/f8m23lOW3QsBvYAe0ZspXkpKClLYjIyAgICAIWAlaxcvcs+x/eeV2tVVd6qOZq7NIGWk+Ov2X9y+JiZctprtylFEQJ+Vm4WzsWd1HXnJwGbo2cULQ2fogYKyeysrbhKjpds9JflFkCZSdqMk6+g/fKCKjbp1ae1i/foSG4qAgEBph2G4VnWTJuUtFVPBuXNAmzYkcqpfH1iwoPDTu7tz3qNbtmgxPokEqFOHti9c4Or7v/6aU1yVAli5fY8eWhzMMFz9fN++ehuTVrD3QkdHUgsICOgJjQP6n3/+Oc/XmjVrMGvWLAwcOBBdu3Y1xBgFBAQECPZmGB5ON2mGUdTPK2Y1cobXoxr5P2/9CUY5jcoGtWzPraSkQtOsIXEheJ/zAR+MRWC0Sg2UIGyGnn1/xRnQs8Z4gM7t6zw9KZHEyu4vPruY93eqIxbGFrAwLvx3GxcHfPMNiTzGjeO6PO3YobdhfDRYWGiZJRMQ+NQ4e5ZS7hYW9MFRCHv2kAloaioF9WfP8jO6Gz2aHrds4dapNYKV3QcGkmmsu7vqov0S4vVrbg2/e3ctTnD7NqkPzMyALl30OjaN8fcno8HBg0t2HAJlDo1N8Vbl60UpFovh7OyM4cOHY/bs2XobmICAgEABGjemosIXL2jikZ1NUm5jY5oBKTGw9kBMPTYVkUmRuJF4A74uvvSCmxvNDtg2allZ5ACvxizuSPQRfDABJv83Cht7bjTgmzMAbIY+PZ0eiyOgz+90D1BAP3cu6UJzclQXhBZBp05A9KUmgO8mrL68Gjdf3sQyv2Vo6tpUp+Famlji/Zz3al8PDSVfqP37uTZtnp5kQPXdd+TRmJ5OQoRPAUtLUucKCHxS7NhBsvnAQF418ArY7PzIkVzpkwp++40asTAM0Ls3tSrn60XXqxclfJ8/J6uSbt34Dw8AyY0AipwBktqXohW7o0fp51KvHlC5shYnYOX2XbrQB1hJ4uysdemZgEBhaJyhf/LkSZ6vmJgYXLp0CUuXLoW1IB8REBAwJBYW5BIMkDyQldu3aFHgRm1vbo+e1XsCALbeVDLHY4PaxEQuCitEdn84+jAAoLuXNqmBEuT1a2qVBHDvr6Qy9A0a0IwzLY160mtBp04AboyC3b0ZMDUyxbnYc2i2qRn6/tsXUa+jdB+3ChYsIEPqvXspmPfzAw4cAKKjgSVL6MeZm0uCEQEBgTJKSgoF5DNncoowPjx4ABw+TAsAU6ao3IVhgKAg4KuvaHvcOGD3bs2M5U1NgS++oG2tzPHYDD1AQW+vXlqcxHDo5G4PcAF9SbnbCwgUA3qroRcQEBAoFpSN8dTI7VlG1B8BANgZuZNzRndzo8e4uCJ70T9MfohHbx7BWGyMjlU6qtyn1MLK7V1dgZcvabskaugBUlWwHgdayu7btwckYgne/bscp3o9xIj6IyAWibH3/l7U/rU2xh0ch+epz3UcPMfmzcCiRbQ9ejSZQJ86BfTsSW+HHRNA0lgBAYEyyunTtHIHcBl3PrCmcj17ymuG8iKVUiC/cCF9v2ABZerZzxdNYGX3wcG8fF7zUr8+aftNTEiOpIkCwcDk5ADHjtG2VgH9w4dUHyWRaFmALyDwcaBxQJ+ZmYnly5ejW7duaNSoEXx9ffN8CQgICBgUNqAPCyMJN5DHEE+ZTlU7oYJVBbz+8BpHo4/Sk2xA//RpkQH94YeUnfdzaQnrPoOogC8zUy9vw+CwAT0bxJubA05Ohr8uG9A/f04Ociw61tFbW3O/+r1b3LC0yRbcHn8bPav3hJSRYkPEBnit9cLsU7PxLvMd7/Nm5mai+87u6L6zOzJz6Xd76hTw5Zf0+ty5wMaNnG+UMp9iQJ+ZSf8GH8W/wpEjNImPjy/pkQh8zLARJUCadtZAozBevwa2ypVhrNGcEpmZZHj/++8UP69fT5l6bWNpHx+gSRNad9i2TcOD7eyAkBBST3l7azcAAxEWRp4Czs5UcacxbHbez4/ep4BAGUXjgH706NH48ccf4e7uDn9/f/Tq1SvPl4CAgIBBYZ3ub96kOnhbW6BRI5W7SsQSDPEZAkCpJz0b4PLI0B95dAQA0K1KZwoOjhzR0nWoBGDr59kg3t29eDIvDg70OwHy9lFiVRRXrwJv3mh1atbPaNUqeQeo9rXhFn4A31UNQ1OXlsjIzcCy8GWosqYKVlxYoQjQC0Mqk+JI9BEciT4CqUyKyEgyQs7NpTr5xYvVH8sG9Nev06TzU0Aq/Yj+FVavJr3usmUlPRKBjxWGoSAeACpVokc+7dx++42i9oYNgdat87z07h2Z3+3dS0nx3buB8eN1Hyqbpd+0SYt2mo0bU6a+lMHK7bt31065IMjtBT4ZGA35P3vnHR5F2bXxeze9QgIkIUAIPfSE3gkYkCZFwE9ABBQQBQFBmo2gIoKKIsIL0kQFQUVp0nsntAChl9BCCYEkECB15/vj5MnsJptsydbk/K5rr5ndnZl9sruzmfs59znH29tbOnDggKG72S3JyckSACk5OdnaQ2EYRpIkSaWSpHLlRI17SerVq8DNz9w/IyESktPnTlLCswRJSkyU9x00iJZffJFnvyepTySnz50kREK6fPOUvE9Kipn+MBPTvTuNd8AAWr78suVeu2FDes21azUfr1mTHv/rL6MOm5wsSZMnS1JYmCQpFPJHAkgSFCqpSpd1UqnPakmIhIRISOVnl5eWnlwqZWZl5nvMlLSUnO2v3EiRKlSg47VuLUmpqbrHVKUKbb9xo1F/kt2RkmJHp0Lt2jTQEiUk6dkza4+GsUcuXKDvkLOzJG3bRusuLpJ0/37++6SmSpK/P227YoXGU3FxklS3Lj3l7S1Ju3ebbqjJyZLk6EjHvnnTdMe1JtWq0d/z999G7HzzJu2sUBT8eTGMDaOvDjU4Ql+uXDkufscwjPVQKGTvNZBv/rygrn9dhAWEIUOVgT9i/iDbnaho7+JCSy0R+h3XdyBDlYEqPlVQ1beqqUZvOUSEXkTlLZE/L9BWGA8otO3e2xuYMQM4eZL6NP/9N1WGDgkBIClwbVN3PPriDLB2GZBcAXee3MFb699C1dn18HfMOp2t7vr0peYJNWpQVXvJIRV7b+xFRlZGvvsUR9u93XDvHi2Tk+nLwjCGkh2dT6zXBjsVEUDTptQZ5X//y3+fP/6guiXlygF9++Y8fPky/es6exYICKAOGuHhphuqtzdQmzp74tQp0x3XWly+TAVInZx0/pvXzr//0rJ1a8Df36RjYxhbw2BB/91332HSpEm4efOmOcbDMAyjG3VBn0/+vDqiJ32O7V7k0Quxq0XQb7pCdvuu1bpCYUNFgvQiI0O2u4tEZ0sKem2t6wBNQV/IPvKlSpE1ft484MIFSpP+7Tdg8CAHVHg0GJh7Gdj6LfDCBzeenUffNT3h+2ErvDvjAE6c0G4XPx1NuZr//Sdh+93VCPkpBOHLwzF+2/h8x8GC3kZJS9NM7Vi0yHpjYeyWF2tJ0E8//jIiOigQ1To7H37+fODFi7w7SJJcOG/06JwWnVFRQMuWlOlVrRrVdFUvLm8qRBOYkydNf2xLI+z2bdvm21W2YNhuzxQjDBb0jRo1QmpqKipXrgwvLy/4+vpq3BiGYcxO+/YkxmvUkKPBBdC/bn84Kh1x/O5xnIs/J4tbUbk4l6CXJEnOn69maFNfG+DaNfrbPDwolA3YRoS+bVu6wL15k0IvJqRcOWrdtGwZHf7qRVcsHDwevW5dh9uJKUCGG5K8D2FBems0+q47fENi8OqrwIKF8jFcXIEZv0bhzb2t8Pqa13EzmSaul5xagsQXiVpfVwj6U6eARO2bMNZAdHZwcACUSuDAAdm1wjA6SEsDvo5MhbRnDwBgK14GAHRZ9CoyA4Pod3XFirw77txJIXgPD2DYMNp3K/3LSkigci8HDwKVKpln3KI2dVES9EZVt3/wgCrqAUCvXiYbE8PYKgYL+n79+iEuLg5fffUV5s6di++//17jxjAMY3bq1aOQ6KZNehV6K+NRJkeYLz+9XI7QiwhLLkEffT8ad5/ehbuTO9oGtzXp0C2CqHBfowZV8wesI+jVW9cBdJHbqhWtG2m71weFgkwCw4cD/6wsiZS1X2FH96to7jwcCskBqLEBTwbUw7/SYHw47XbOfo2mDcXQo01x6PYhuDu5Y1r4NNT1q4vnGc+x9NRSra9Vtiy9zZJEFlrGRhB2+3LlgC7Zk3KLF1tvPIzdsGULdbXYOW0/3PECD50D8euJOmjWDHiU7IifHLJ7ys+enddpJKLzb70F+PhgxQoSpM+ekW181y5yAZkLIejt3XKflCTrcaME/fr19Nk0aiT/v2eYIozBgv7QoUP466+/MGnSJAwePBiDBg3SuDEMw1iEtm2BypX13lzY7n8/8zuygirQg6I0eS5BL+z2EZUj4OroWvixGsqLFyQ+Ll82bn8RiaxRg5LCASA42CRD0wthub95E0hP13yukHn0xqBUAi81CcShKQtxYdQ5vBrSG1BIQOhyKEbKvteDT1YBAN6s/yYuj7qMz9p+htFNRwMAfjr2E7JU2su6s+3eBhGCPiAgJ1KK5csp9MowWrh1i9zZnTuTuehVd7Lbl+7fEWENFFi9GvDxAabefhupzl6U6yMq4APA+fPA5s00ozhmDGbPJteQ6JixcSO13zQn9evTy8fFySYVe2TrVnrfataU/50YxJo1tOzd26TjYhhbxWBBHxISghfa8oYYhmFsmK7VusLXzRf3Uu4hxiWZHkxIkJdqSdX/XaH+812qZkf2PDzkguoeHuYd6NGjlAg5bJjch8hQRIS+bFm6KnJ0pHVLUbYs9b1XqYAbNzSfE4J+9+68Yt8C1ChdA2v+728cHXoU4cHhkJTyGFpWaImooVFY3nM5ynlTi6r+dfvD180XN5Ju5HwvclOcBL0lT4VCcf8+LcuWpQh9YCCd5+vXW3dcjE1y/ToFc//9l7I0xo0DhgeTWFdk98sMCqIe709QAvPTh9KOIiIP5LSzk3r2xMSFVTA+u/TG2LFU38PZ2fx/h6en3ErenqP0hbLbJyVR6gPA+fNMscFgQf/1119j/Pjx2LNnDx49eoQnT55o3BiGYWwRF0cX9K/THwCw8ulBelBc9EsS8OgRACDheQKO3DkCwML582lpwJQpVPBPCPJjx6jAnaGICL3oB1+hgpFNfI1Eocjfdh8aSp7TlBTgyBHLjSkXTco1wa43d2HzgM3oX7c//uzzJ/YP2Y/G5RprbOfu5I6hYXTxPjdqrtZjiUrVZ87kfI0YayMi9GXL0oTWkCF0n4vjMblISiLh+PAhULcuEB0NfDcuDg7nY+i3TK3warduwIQJwI8YjSwoge3bKWf+4UNS+wCmPx+Hb76h7WfOJM2vNPhq23hsPY8+IwMYNYpuonarOllZlE0HGCnoN26kiezateXZDYYp4hj8E9OpUyccPnwYL730Evz8/ODj4wMfHx+ULFkSPj4+5hgjwzCMSXi7wdtQQIEVSQcAANKdO4Ao5pltu996dSskSKjnXw8VSlSwzMBOnAAaNgS+/pqi2m+8QWI8LQ04d86wY0mSLOgdHWlpyfx5QX6V7pVKuQeRul3VCigUCnSq2gkrXl2BvrX75tvN4L3G70GpUGLH9R04//B8nuf9/OR2UXv3mnPEjN6oW+4BymkGSIDFxlpnTIzNkZFBneUuXCATx+bNlD+f89vUuDG11FBj+nQgsHkw1oDs3Fnffk9t7NLScKlEY3y6tSUcHIBffgEmTtSrzItJsXVBP20adSeZN4/09qBB8hw2QPO8jx9Th1n1hjZ6w9XtmWKIwYJ+9+7d2L17N3bt2qVxE48xDMPYKqEBofj5lZ9xzwvIUAKKzExIuQR9Hrs9QK3f+valm2gDZwrS04GpU6m38blzpAz/+Yf8mY0a0TbHjhl2zIQEKreuUMiWdmsI+vwq3QNySDsqymLDyY/UzFT0/asv+v7VF6mZ2j/biiUronuN7gCAn6J+0rpNcbHdm+tUMDnqlnuA6m2ISOtS7QUOmeKFJAEjRwI7dgDu7hTYLVcu+0kh6F9+Oc9+Tk7A6tXAEm9qYSf9vgKqH8m9MzV5HNzcFFi3joSqNbDlwnj79gFffUXrTZtSNP7XXylXvl8/ICZGttt37izPSevNs2dU1RDg/HmmWGGwoG/btm2BN4ZhGFtmaIOhWNRzCe5k97W9nZXdayw+HpmqTGy5ShcDXat3lXfKygL+/ptu2hqYG8OZM3RF8/nndMy+fUnUixY7QtAfP27YcUWoIyhIjlJaQ9ALq+OZM3mfE+HsCxcsN558yFJl4e/zf+Pv83/nW/QOAN5v8j4A4NfTvyI5NTnP88VF0JvjVDAL6pZ7gSiOt3Sp3LKSKbbMnk0ZGAoF8Mcfcg93ZGWRkwPQKugBymIavbIZDqE5HFXpUD5KwC1UwG6f3ti5E+jaVetuFkH8Hdev21YrzaQkYOBAmkgZMoQi8VFRQPfu9NiqVZTy8OOPtL1RdvstW6iobOXK1A2HYYoJBgv6ffv2FXhjGIaxdd4KewtulUlwxqVT0rPqwQMcvXMUiamJ8HH1QbPyzczz4pmZ5Nls1IiSNUuVonDPn38CpUvL2xkr6IXdPiSEqswD1hH0oj3d4cN5Q7k1a9IyLg54+tSy4zKSdsHtULtMbTzLeIZl0cvyPN+mDS3PncvTNIGxBrkt9wDQowedY3fvkreaKbasXUu58ADw3XckKnM4fpyUcIkSNOmaD127Atd7jMu5/0wZVWcAACAASURBVGuJ0dhz0AnNm5tp0Hri4yM3NYmOtupQcpAkYMQI6iRQpQowZw493rgxsG4duQlEQP35c8rMyq5FaBjqdntL5zowjBUxWNCHh4fnubVr1y7nxjAMYw8E1M6+UMv+n7/l0HJsvExev5ervgxHpaFePz04fx5o3hz45BNK3uzRgzyGr72Wd9vG2cXZzpwxzNus3oPemoI+JITEVFpa3uJ3Pj6Avz+tiwkIG0ehUORE6X+K+gkqSaXxfOnSckBozx4LD47RRKWSe3apR+hdXIA336R17klfbDlxAhgwQBaZY8fm2kBYtiMidHq+/++Pnrjm2wj3XIMx5ODQnLlKa2NrefS//07z1g4OwIoVedv3hYaS6ycmhtIgFi6Uy9voTVqa7Nfn/HmmmGGwoE9MTNS4xcfHY8uWLWjcuDG2WbCvMMMwTKEICgIAVCtRCQBw5+opfHv4WwDU4s6kZGUB33xDV1nHj1O1n99+ox5J6hHE3OMrXZoi+tps6/mh3oPemoJeoZBz5bX50MWVrw3Y7vXljXpvoKRrSVxLvIbNV/JGeIuL7d7mefSIzhuFQp44EgzNbjf2338UqWeKFXfuAK+8QlHgjh3J3p0nkFtA/nxunNwcUSX+CMo+vYJytUuafsBGYkt59Nevk0gHgMjIAk0PqF0b+Okn+TQ1iJ07gSdPqLphQS/CMEUQgwV9iRIlNG6lS5dGhw4dMHPmTEycONEcY2QYhjE92SK3tIKaafs/BzJVmVCAKp+bjMuXgdatqdxxWhpV+omJoUr2BVkCFQrjbPciQh8QQLmEACV8WoP27WmpTeGGhNDSjgS9h7MH3gqlaunaWtixoLcRhN2+dGmqYKZOzZqUDpKVBSzLmzrBFF1SUkjM37tHwvHPP/N+PZCYCBw9Sut6CHoAFHY2uHqbebGVCH1mJv2re/qUTrspU8z4YsJu36uXZfsEMowNYLJvvL+/Py6p951gGIaxZbIj9HjyBADQwqUaHJWO6FS1E0q7ly5gRz1RqShRMDSU8si9vMjm+99/aqWUdSBs9/pWuk9Plxv7urnRsmxZshpbA6FwjxyhkJg6IkJvJ5Z7wcgmI6GAAluvbcWlBM3/eW3a0DzMpUsc/LUq2vLn1RHF8ZYsofOUKfKoVFSQLToaKFOGnNklSmjZcOdO2jgkRP4fYYeIwngXL1Lhd2sxfTr9+/P2Jtu9g4OZXigzk5LxAbbbM8USgwX9mTNnNG6nT5/Gli1bMGLECISGhppjjAzDMKZH2NATEgAAZVJUiBsXh7Wvry38sa9fJzE7dixFySMiKCr/9tuGFeoxNEJ/7RpFHj095as4a9jtBVWqAOXLU72AQ4c0n7NDyz0AVPapjG7VqfzyvGPzNJ7z8ZEvpDmP3orkblmXmz59SM3FxlKzcKbI8+mnVAjP2ZmWomhcHoTd3qiKbLZDQAB9/SUJOH3aOmM4dIiauADAggVm/ld04QL9L/f2liuUMkwxwmBBHxoairCwMISGhuasd+nSBenp6VjMRWYYhrEXhA1dRI7j4+Hn4QdnB+e827q7k18zJYXW80OSgP/9j6qj7dsHeHgA8+cD27YZF+0Rgv78ef3CLDExtKxRg8oJA9YV9ApF/j50IeivXiVngZVwd3JHypQUpExJgbtTrs92715S6atXazwsiuMti16GJ2lPNJ4r6rZ7fU8Fq6KtZZ067u7A+/QZYtgwqtLFFFl+/13ufb54MdCiRT4bSpJcEE9fu70NY848+rQ0KtFy5Ag53efNo1qvb71FWWWhoVSjQKUiy32/fqYfgwaiXky1ajaX/sAwlsDgb31sbKzGfaVSiTJlysDV1dVkg2IYhjE7Hh6UY5sdocfTpxRNF1Z1dRQK2r4gbt2iCPyOHXS/TRvK0a1c2fgxBgbS7e5duioTreDyQ1yMtmghX+DkG4qyEO3aUQHAXbs0Hy9XjpwEKSkk6mvVssrwFAoFPJzz+Wz//JOaJy9YAPzf/+U8HFE5AiGlQ3Ax4SJ+O/0bRjYZmfNcu3bUBquoCnp9TgWro8tyDwDTplEkf/FiqnwvSaQ8mCLF4cP0swxQ/vbAgQVsfOECVc1zcSkSUd4GDSjDy5A8+hcv6PS5e5eW4qZ+/+5d4PFj/Y4nityZHfH/zo7TJBimMBgs6CtaM9rDMAxjSoKCSNA7OJBV/eFD7RcEKhX10WnUSM5rF0gSsHQp8MEHNCng5gbMmEERQFMU5mnUCFi/nmz3BQn6rCxgwwZa79EDmJtdtM3av9kiZH3sGL0/ol+RQkF5qsePU6KnlQR9gYi6MIcPU+vA7IlrhUKBIaFDMGnHJOy6sUtD0LduTV+na9eA27etV4+wWKPLcg/QublwIX0PFy2SRX2Bio+xJ27eBHr2JANQz57Al1/q2EHY7du0sWH7if7oWxgvK4s6p+7cCSQn6398Z2c6xcQtMDDv/Zo1aTuzIxxpLOiZYoregn7Xrl0YNWoUjhw5Am9vb43nkpOT0aJFCyxYsACtW7c2+SAZhmHMQsWKdLXj6UlXMvHx2i8IVq8G3nuPlNr27bJIjYsDhg8HNm2i+82bU05u9eqmG6O6oC+IqCiakChRgi5Ix4+nx60t6IOD6XbjBnDgAPkxBTVr0t9lxTz6tMw0vLPxHQDAwm4L4eKoVkBQCPq0NHp/1aJ2jQNpYufkPc2rZW9voGFD2nzPnqKnD9PSgHfo7cLChdart1gguiz3AqWS3BcKBfDzz8CgQSTqRa96xm55+pQq2sfHk/37t9/0mF81oF2dPSDqecTE0Hmb37m6YYNcIB6gOen8BLr6fV9fw0rCmBUW9EwxR+/w0Q8//IBhw4blEfMAtbJ75513MHv2bJMOjmEYxqyIf/7iSic+Xvt2v/5Ky6wsaolz5gxdIdapQ2LexQWYNQvYv9+0Yh7Qv9L9+vW07NyZejFZswd9bnTl0VtR0GeqMrH89HIsP70cmapM+Ylnz8h+K9i7V2O/0AAqAnsj6QYSXyRqPCe69f37r1mGbFUyM4Hly+mWmal7e6ugj+VeoFRS3YsRI0jMDx5Mfxxjt4i87bNnAX9/+mn09NSx04MH8u+TnRfEEwQFkejOzJTLq2jjhx9oOWYMZRg9e0YOo/37Ketozhxg8mSa5+rQgf7tlSplQ2IesI2aMQxjRfQW9KdPn0anAn7kOnbsiBMnTphkUAzDMBZBCHoRutEm6OPjqaidIDkZaNKErm6SkiiCfvIkMGGCeXryNGxIy8uXC/ZDCrt99+7Uii8pie7bwgVOfv3obUDQ58vly5r3cwl6HzcfBJcMBgBE34/WeE6kYq9fz+3rrIK+EXqBUklVvd59l0T9kCFc/d6O+fhjOvdcXKiTmV5pL/Pnkze/SRPbTP8xAoVCd2G8U6fop83BAfjwQzJ42ZRQ1xfOoWeKOXoL+gcPHsDJySnf5x0dHfHw4UOTDIphGMYiCLErQo3afsP++EOzV7VSSf5FAJg0ifKrzXkBWKaMPM78kiGvXQPOnaPqvp06yRc3vr56hKYsgIjQnzypOSkREkLLixdtrx+4sNv7+dHy0KE81fjDAsjTeuq+5tVy7dpU7iAri1qdMxYkJSWnI8RXy8qiRg0954tyi/q33qKiloxdsXs38PXXtL50KdC0qR47vXhBgh6gVCW7VLTa0ZVHP2cOLfv2pQ6jdklGhjxzyoKeKaboLejLlSuHmAI8O2fOnEFZfWfDGYZhbAHxzz81lZbaIvTCbi9QqcjSDlDkXrS9Mye6bPciOt+6NbVZsyW7PUAV7atVo/du3z758SpVaBLi+XNNe7stIAR9167UDeHFizzvf4OydLWcW9AD5OAGqN5aVpZZR8qokx2dT3XyxMczPHH5smwp1olCQaJ+5EgS9W+/TaqQAUD9zFetorfGFnn6lOZhAKrz0L+/njv+/jsVRw0KAl591WzjswYij16boH/wgOarAWDsWMuNyeTExdGX0sWFJsAZphiit6Dv0qULPv30U6SKC181Xrx4galTp6Jbt24mHRzDMIxZEYJX9HjPLejPnaMrIfWIzaRJ5FMsU4aWPXrIEwLmQvSjz68wnsif796dlrYm6AHtefROTiT0Aduz3QtBHxICtG1L67ls9zkR+nt5BX3v3pRnevs2sHmzWUfKqJF+kwT97Qw5f/7PPw04RRUK6hAxapQs6tlmAYAqoffrR63QbJEJE6j2ZsWKwDff6LmTSgWI+k9jxhS5HuYiQn/6dN6aFwsWkOmoWTM9nQy2inpBPFN0lmEYO0Tvb/4nn3yCx48fo3r16pg1axbWrVuHdevWYebMmahRowYeP36Mjz/+2JxjZRiGMS1lylArMhFyyi3of/uNloGB8mOffkqe6i1bqAXbnj0UCjJnGLYgQZ+YKEe9X3mFlvYi6AHbzaMXgr569fwFfVkS9BcTLuJFxguN51xdqWg6QNXgGfOTkgLMHEct6+4ryuLPP8kckpRkoAhVKIAff6TWkwAwdCj1qy/GPHggl5X4+WfrjkUb27bJ59myZXJ3TJ1s2UIpP15e9DkXMapWpayr1FT5Jw2grDGRZWDX0XmA8+cZBgYIen9/fxw6dAh16tTBlClT0KtXL/Tq1QsfffQR6tSpgwMHDsDf39+cY2UYhjEtCoXmRYC6oM/KIismQEXmctOgAVVccnamcuaiSrY5EIXxYmPJGqrO5s001tq1ycIO2KagDw+nZXQ08OiR/Lh6Hr2tIEmyeqlRQxb0Bw9SvmY2ZT3Lws/DD1lSFs7Gn81zmOHDablpkxxEYszDo0fASy8BCWcpQl+tTVn07SsXKBRzc3qjUFCC8ejRdH/YMNtUshbi6FF5/b//yOVsKyQnk5ECIGOFmDvUCxGdHzaMek4WMZRK7bb7Vavo31358kUgy4Bb1jGM/oIeACpWrIhNmzYhISEBR48exZEjR5CQkIBNmzahUqVK5hojwzCM+chP0O/eTVetXl6UnOnpSffd3eVt2rWjKyOlkiJ45nIplSwpW9NzdxNRr24vsEVBHxAgR+PVI91WjtC7O7kj/sN4xH8YD3en7M/23j0K9zo40CRJnTpUYPDZM433X6FQ5Njuc/ejB2guoF07cvUWlQCvuzudJvHxmqeCNYmLA9q0AaKigMquJOgD6pPlfuBA2mbTprxzYTpRKCgBf8wYuv/OO8XWbnHkiLyuUtlWE4Bx46gER5UqckE8vTh9Gti5k85zMXFTBMldGE+S5LoSo0bJJWHsFhb0DGOYoBf4+PigcePGaNKkCXx8fEw9JoZhGMuhLnrj4+UouyiGJ/rKd+pE1vvcFZB79ZIv8mfMAL7/3jzj1Ga7T0+XE7RtXdAD2m33Vhb0CoUCZTzKoIxHGSjEZyu8qZUqkQNDqSTFCBiURw/IxfEWL9YI7tstCgVlqpQpYxvFwI8dA1q2BM6fJ3v9oJfJci9a1tWuTRHKjAxg9WojXkChoHP6gw/o/ogRlHxczBCCXpwGS5bYRmOKTZuobqFCQVZ7Dw8DdhbR+T59bO+30oTkjtDv20dGKTc3MibYPdyDnmGME/QMwzBFBvVZ/fR0stenpABr1tBjKSm07No1/2MMHQp89RWtjxtnhL9XD7RVut+/n/ymfn7UPxmgZMn72aLG1i5wtPWjr1GDlg8falrxrYkQ9GJsgGy737NHY1ORR6+t0j0A9OxJH8+9e8DGjaYeaPEkNZXm25o1o6/9zZtkYDlwACj5Im8PehGlN/q0VCiA776jcxug1nb/+5/xf4CdkZUl/+x88w31Ko+NBXbtsu64EhNlQTp2LDX50Ju7d+US7+JzLaKo96JXqeTo/JtvkvHI7uEceoZhQc8wTDFHiF4HB1rGxwP//EOt1CpVksXd3r3Uzkr0oM/N5MlyFG/IENOXgtYWoRfV7V95Ra7ue/s2LT08qMy6LSFE8blzcnqDpydQoQKtWyGPPi0zDSP/G4mR/41EWmb2Z1uQoD9wQKNctIjQn40/i0xVrjLSoAC/aKVVFNzaaWl0GhR0KpiL2FhqMlG+PBUcPHqU7MIDBtDcVnAwctrWIUCuct+vH50eR4/KpREMRqEAvv2W+pQDwHvvyVXFijjnz9O8pqcnlfMQdQkWLbLuuMaMIV1evTowfbqBO8+bR7aNli3lydAiSs2aVKTz6VNgxw4q/QIUkSwDSWLLPcOABT3DMMUdcREgBHF8vGy3r1+flg0aUNLo/Pl5e/8IxAX/wIEU0urbl4qomYqwMBpjXByJFknSFPQCdbu9LXii1SldGqhXj9bVI91WtN1nqjIx//h8zD8+Xxbk2gR9vXpUyyAlhUJd2VTxrQIvZy+kZqbiYoL2CQkRRdy6Fbh+3Rx/heXIzKTToKBTwdRcvAh060Y50rNmkZGjQgUScbdvU+3KnJq89/JG6AMCgJdfpnVR59IoFAoKUU+YQPdHjiRhWMQRdvsmTWjeUxSD//dfMtZYg3XryHGhVALLl5N9XG+ePZPTJsQETRHG0VH+2X3vPfrX8fLLQK1a1h2XSUhMlNvOiolhhimGsKBnGKZ4IyL0Qp2cOCF7SV9ktyLr1Em/YymVlFzatSvt260bcDZv9XOj8PSUhe+JE0BMDDVddnUFIiLk7W7coKWt2e0FNphHnwdtgt7BQfb0quXRKxVKhAaEAsg/j75yZaBjR1q3dlTTHpk0iQwvkkTv49q1NDHy0UdqQh6giKuofKcm6AHZdv/774VsRqFQADNnAhMn0v1Ro4CffirEAW0fIeibNaNlaCgZhjIyzJNdpIuEBLmDxIQJ8rj05tdfgceP6cRUrz1ShBF59Neu0dLuW9UJRHTe35/+FzJMMYUFPcMwxZty5egiXVzlz5lD661byxF2fQU9QB7gP/8kK2dSEoVCYmNNM1Zhuz92TI7OR0RoVoKy1YJ4goIEfUwMqbWxY2ndGqSlyZMioiCiIL88+oCC8+gBuTje0qVUqoHRD0kCDh+m9c2byeXQowdFHfPw4AEtHR3zpJv06EENK2JjTWCcUSionPqkSXT//feBuXMLeVDbJbegB2TXyaJF5uvWmR+jRpGRqlYtIDLSwJ1VKrlw6dixcqpVEUfk0QPUKVRMMNo9nD/PMABY0DMMU9xxcdHIt83xRDdpQvZqf38KSRmCuzu1k6tblyzAHTvKYqMwqOfRa2tXB9i+oG/ThgTRpUuUAKtSyU6IHTuoa8CcOZSoa2mlAABXr9KYvLw0vxeALOj376e0imxEYTxtresE3bpR0Dg+nuYsGP24cYNs3U5OQHi4jo2F3d7fX06hycbdHejdm9ZNElVWKKirxeTJdH/0aODHH01wYNsiOVk2zjRtKj/++uv0nl68aNrMIl389Rd1K3BwIKu9wUHZjRuBK1cofWbIELOM0RZRF/RjxuQ5PewXzp9nGAAs6BmGYfKKX1dXWWR26WLc1Y+PD7BlC1XqunoV6NyZKugXBlHpfv9+qvAFkFJUx9YFvY+P7P98+226EBPFBFUqUr3u7tQjetMmy49P3W6fuwZBaCjg7U2f4+nTOQ+LCH30/WhI+UxCODnJucdFoTiepYiKomX9+nqIt/uaLetyI2z3q1dTpfxCo1BQd4uPPqL7Y8bQZFQR4tgxmlerVIm6NQi8vUnUA5ZLI4mPpxxwAJgyRZ7fNAjRqu6ddyiNqZhQty79SwgOls+DIgELeoYBwIKeYRgm78VAr17A9u20XlC7Ol0EBgLbttGV8KlT5PstjJKoV4/sxE+f0v0mTfKKF1sX9IBsu9+yhYr8lSxJTgmAnAfiqn36dMtH6bXlzwscHYFWrWhdLY++VplacHZwRnJaMmKT8k+vGDqU5oZ27ZJfhikYMW+lHh3OFy0F8dQJD6cK+cnJJmwhqFAAX34JfPwx3R87VvaoFwG02e0Fwnb/11+UXWROJInSVhIS6Gfw00+NOMi1a3TeKpXk2y9GuLhQFtOZM5oZWnaPPfy/YxgLwIKeYRgm98XASy+RLdPJCejQoXDHrlaNhKuXF+Ve9+9vfHlwNzegTh35fm67fWYmcOcOrdvyBc4771CUvm9fKpV9/74cbrtyhfpCu7hQ8rSacLYIoq+ZNkEPaM2jd3JwQh0/+lzyK4wH0LxRly603qEDsGqVdbIK7Akh6PXqLKalZZ06SqXccs2kxdwUCuCLL+QP15IedDNTkKBv2hSoXZvMTCtXmnccf/xBPxWOjmS1d3Y24iArVtAyIoJmdooZnp70b6hIwRF6hgHAgp5hGEbzYiAgQA43tW5N3lI3N6qmFRtrYH+kbMLCqIidiwtdlb77rvFKTtjugbyC/u5dyu12cso3SmkTVKsGnDxJxQN79qT3Rb3SfdmycvN2gxtMG4abkxtix8Qidkws3JzcCo7QA3Ii9/79lCKQjT6F8QBKuw4KonZr/frRV+zEicL+FZajsKeCIWRk0NcE0DNCr8NyD8h2402b5IL4JkGhoCbtQJGxX0iSLOi1vf8KhWWK4927JwfUP/3U8JImAGhwomehmNVh7B8W9AwDgAU9wzCMHM2uUIEaHG/ZQveF3V6ppOTD4GDjqwmFh1OYSakEFi+WLbqGIiLZFStqRusB2X5YoYL9VT0KCaGlqMA1cSJVvtqxQ06kNgNKhRLBJYMRXDIYSoVSt6Bv0IBCXYmJGi0J9RX0depQIbHPP6dSAQcP0hzN0KGmqZtobkxxKujL2bOUoVKiBM0B6USH5R6gyugNGpCZZfVq04wzB/GduXjRxAe2DteuAY8eUTQ8PxE9cCDNx0VHy5MvpkSSyNCTmEif25QpRh7o+HFy/7i7U0oVY/+kpcnnPAt6pphjN1d8jx8/xoABA+Dt7Y2SJUvi7bffRkpKSoH7/PzzzwgPD4e3tzcUCgWSzJ3kxTCMfSIuBl68oEixsHkXJn9eG716yRXRZsyQ2ycZQv/+FGH68ce8RdtEe7zg4EIN0yrk7kUfHAwMGEDrM2ZYZgwJCdSfGshfQTo6UktCQCMdQFS6L8hyL3Bzo0jjpUv0J0oSsGQJveQ339B1KqNpt9dr8kCH5V4govQm76EuBH0RidCL979BA7nERW58fYFXX6V1cxTH+/VXKqvh7ExWeycnIw8kovM9exarYnhFGpFe5uYGlC5t3bEwjJWxG0E/YMAAnDt3Dtu3b8fGjRuxb98+DB8+vMB9nj9/jk6dOuEjUYGWYRhGGyJCn5BA1viMDKBKFbkPeXo6MGEC3QrbRHzoUFmgjhtHV6yG4OlJSiS33R6QI4P5RZdtGSHoL1+WW8JNnkyTFmvXmq0vfXpWOiZsm4AJ2yYg/UL2a1SoQJG8/NCSR1/fvz4UUOBeyj3cT7mv12uXL0864+BBMl48fUrGhDp1SMTYYn69KU8FXQhjhl52e0Avyz1AqQ4ODiRYTVq/Tpx38fHmrxJnAQrKn1dH2O5XrqSfT2NLhOTmzh1qHAAA06blNSTpTUYGuaMAeZKQsX/U7fa5J7cZprgh2QHnz5+XAEjHjh3LeWzz5s2SQqGQ4uLidO6/e/duCYCUmJho8GsnJydLAKTk5GSD92UYxk5QqSTJy0uSAElq2ZKWo0fLz6ek0GMArZvi9caNo+M5OEjSxo2FP6YkSVKvXnTMOXNMczxLkpUlSa6uNP4rV+THe/emxwYMMMvLpqSlSIiEhEhIKYvm02tFRBS806FDtF2pUjTubEJ+CpEQCWnT5U0GjyMrS5J++UWSAgLkr1qHDpIUE2PwocyKqU+FgqhZk15n/Xo9NlapJMnZmXa4eVPn5j160KbOzpI0a5YkZWYWfrySJElSYCAd+MgREx0wf06elKTvv5ckc12eNGpEf8qqVQVvl5UlSXXqyN+LwEBJ+uQTSYqNNf61VSpJevllOl6TJpKUkWH8saRNm+hAZcpIUnp6IQ7E2BS//CL/UDJMEUVfHWoXEfrDhw+jZMmSaKTWdDQiIgJKpRJHhSfMRKSlpeHJkycaN4ZhijgKhRylFxWqTW23z/1633wDvPkmRaP79jVNZWwRoRf56PaEUilHOIXtHpB7fP/xByX1mpMrOircCxo1ogj+o0fA+fM5D+ubR68NpRIYNIgMCpMnk8V4+3bqvz56tJwJUFxITpa/zo0aZyHhuY4Kdo8fy5YBf3+dx1+0CHjlFdpl4kTqpCgyVgqFBW33I0YAH3xA5pZ//jGto+PFC8qLB3Q7JJRK6s754YfkfL57lzr5Va4MdOpEY8vIMOz1lywBtm4lq/8vv1Cmi9EIu/3rrxfCs8/YHFwQj2FysAtBf//+ffj5+Wk85ujoCF9fX9y/r5+1UV9mzJiBEiVK5NwqVKhg0uMzDGOjqF8UeHjItmpzIYrjde1KV8/dumkUWTOYjAzg6lVat0dBD+TNowcogbdTJ6ooP2uWeV//yhVa6hL0Tk5Aixa0rp5HXwhBL/DyooyMCxeo5EJWFjB3LuXXz5tnmJ05M5PesiZNgAMHjB6SVTh+nARqcDAw99yn8PvGD+svrc9/B5E/7+ubf8K3GmXKUP3LxYspi2X/fupvvnRpIYWxBQvjiQ6Ld+8CvXsDPXrIGqewnDxJ3x9/f/06YJYtS3OUd+5QscGXXqL3cetWGlv16sD16/q99s2blI0EUJML8bNgFE+fUmcRgKvbFzVEEVgW9AxjXUE/efJkKBSKAm8XLVwtdsqUKUhOTs653b5926KvzzCMlVC/KIiI0EsUFBonJ2rd1qoV5dy+/LLxYcLYWBL17u7222NZXLnn/t0XHQF++QWIizPf61/WU9AD9JkBpDyzMaQwni4qV6bI5s6dlDv8+DG17goNpcd0ceEC1e6bNAk4dozyxpOTCz0siyHMd42bSFh+ejkkSPh418dQSSrtO+iZP6+OQgG8/TZw+jR9nCkpdL9XL0qDNwoLReiTkuQ0/QkT6Kdkwwaq4j97duHz2MX736yZYenJLi7Aa69Rc4qrV8lt4ucH3LhBjghdpkeVijpWHl73IAAAIABJREFUPn1K39+xY43+E4i1a2nCtFo1zZafjP0jZq/0mXFimCKOVQX9+PHjceHChQJvlStXRkBAAOJz/XfNzMzE48ePEaCjmq2huLi4wNvbW+PGMEwxQP2iwJx2+9y4u1Mlqbp1KcrYsaNx/cvUC+LZW8s6gbYIPUBqq3Vr8kd/9535Xj82O4Soj6AX24ioPuQI/bXEa0hONY16bt8eOHUKmD8fKFUKOHeO5pt69dKegZCZCcycCYSFUVG5EiWAcuUocjphgkmGZBFEQbygRmdw9+ldAEBMfAw2XNqgfQc9WtblR+XKVN9w5kwSxuvW0STKunVGDNxCgl4EJ8uUIRfGqVN0mjx7BowfT9r12DHjj69vQbyCqFKF3CYnT9LHcv48TSyJmpfaWLAA2LWLCpcvW0bFCwuFeu95LpxWtGDLPcPkYNWrvjJlyiAkJKTAm7OzM5o3b46kpCScOHEiZ99du3ZBpVKhqd7lbxmGYQpA/aKgSxfLvraPD7BlC/mLr14FOnc2PJxqz/nzAvVe9Ll9zyJKv3AhdSMwBxmZpCT0SbUSbe1EmgOAUu6lUMGb9j394LTJhuXoCLz7Ls0djBlDImftWorGTp5M0UxAjspPnkyt77p0oQmAlSvp+UWLKNdZHxITyTpt7kr22pAkOUKcUnYTAMBBQcpu+v7pkLR54vVsWZcfDg6US3/sGM2tPXxIHc7eekt3VFkD8R2+erVg5VpIbtygpehQWbs2ZX8sWgSULEn5702bUv0FY0oBCUFvikuscuVocsTVFdi0iVwj2rh+XZ50+vrr/DtH6s39+2QVAKjdJ1N0kCQW9Ayjhl2EcWrWrIlOnTph2LBhiIqKwsGDBzFq1Ci8/vrrCAwMBADExcUhJCQEUWJaH5R7Hx0djavZF1xnz55FdHQ0Hhe36kIMw+imUSO6qg8PpytQSxMYSFXQ/Pwo3NajB5Caqv/+RUHQV69O7oLkZNlCLejYEWjYEHj+nHzRjx6ZZwzVqunncKhalZYPHmgoJlPa7nPj4wP88ANw5gy9HenpFFWuVo3s+OpR+WXLgI0b6avcpg3w/vt0jGHDdAu8+HgyRLz+OhAZafI/Qye3b9PH7+AAnE0lQf9Z28/g5uiGY3ePYcf1HXl3MsJyr4369UnUT5xIAd1ly+ixffv0PEBQEPnO09LkMLoZyC3oAfraDh1KPwUDBpDmmTvX8KJ5cXH0GSiV9LNoCho3powZgEw2y5ZpPq9SAUOG0Ondti19nwvNqlV04GbN5POVKRokJFAqBWC/KWYMY0LsQtADwIoVKxASEoKXXnoJXbp0QatWrfDzzz/nPJ+RkYFLly7h+fPnOY8tWLAAYWFhGJbdJLVNmzYICwvD+vUFFNZhGKZ4Ur06hTj/+Sfvc25u1Ac9JobWzUXVqhSp9/amcNv48frvWxQEvYsL+Z+BvHn0CgXw1VekMtavp5Dk2rWFfkk3JzfEvBuDGPcJcMuEfnZ7gFRzmTK0rhalN0VhPF3UqkVfk6VrbiMgYhUeNHgf85I6I6300Zyo/ODBmg7jGTPorb11i8Rqfjx8SAXNzp2j+z/9RNF6gSVOBTEvX6thIo7ePQwAeLP+mxjecDgAitLnoRCW+9y4uNBEyd69JJhv3KB5vgkTSKcXiIODHFo2Yw0gbYJe4O9PTvNt28j2bmjRPOGOqFOHijSaiv/7P+Czz2j9nXeoEKFg7lyaNPHwoMKEJskaUrfbM0UL8UUuW9Yy9W4YxsaxG0Hv6+uLlStX4unTp0hOTsbSpUvh6emZ83xwcDAkSUJ4eHjOY5GRkZAkKc9t8ODBlv8DGIaxfapVozBobpRKEpC1a5s/Pz0sDFi+nNb1TeKVpKIh6IH88+gBCksfPkzbPHhAieQDBhQqWq9UKFHbrzZqX02GUgJN7OiLFtt9g7INAAAn7500ekzayFJlIfp+NOZFzUO/Nf1Q8YcgvHU2CPdb9QOa/gRU2wK34R3x+aKTWg0mHh7UCgygrIUdWoLcCQmUnx8TQ9fJNWqQnX/uXHkbS5wKQlD6N9+OLCkLNUvXRHDJYHzY4kM4KZ2w9+ZeHLyVq81jIS332mjdmtwQb79Np9i331Kk+bSubAoL5NEXJOgFHTpQ44xPPjGsaJ56QTxTM3Uq0KcP1e989VWq5Xn5MjBlCj3/7bfynF6huHABOHGC8lVee80EB2RsCrbbM4wGdiPoGYZhig0RERRejYvTr0Dew4cURlUoTJB4amWEoFfr765BkyZUZWvyZFKUK1eSujSqgpkaQnzpG6EH5PdaS2G88w/PIzXTgJSJXKSkp2DH9R2YtmcaOv7WET4zfRC2MAyjNo/CqphVuP3kNhwUDmhYtiFGNxmNFhVa4IX0BC//3hEx8TFajxkeDowcSetDh8q59wDNiUREkIANCAB27wamTaPn5szR3NbciAj9i/KbAQBdqlFNi/Le5TGo/iAAwFcHvtLcyUSW+9x4eVFru3XryJBx9iyJ+pkzC0iRtxFBD5CL4osvKKde36J5piiIlx9KJVnvw8JoAql7d2DQIHJPR0RQ5N4krFhBy06dZCcNU3RgQc8wGrCgZxiG0UV6OiUTR0ZapkqYp6ccaVcrBpovIjofHGzelABL0IAi3Ni1K/9tXF3JQ64ere/Z06hofXpWOiL3RCLS6zjSHWCYoBd5uWqCvrx3eZRyK4UsKStfYa2NO0/uYHXMaozePBoNf26Ikl+XRIffOiBybyS2X9+Op+lP4eXshY5VOmJa+DTsGLgDSZOTcHz4cczpPAebB2xG48DGePTiESJ+jcCVR1e0vs7XX9PX5OZNuTjZ48cUzT19muzau3fT29CnDxkWHj+m6uOA+U+FzMzsToAKFS5magp6AJjUahKUCiU2XdmkWafAhJZ7bXTvTs6FHj0oujx5Mk2QaO2tLs5dGxD0glq1KIVg8WIyIeVXNC8zUxb65qo57OFBWTMBAfSeHjlCEydLlpioEL1KJQt6ttsXTbgHPcNoIjEFkpycLAGQkpOTrT0UhmGsRUqKJJHrltYtwRtv0Ot9/rnubRcupG07dzb/uMxNUpIkOTnR33P+vO7tX7yQpMmTJUmppH38/SVp7Vq9Xy4lLUVCJCREQkpxAr2+vqxaRa/ZsqXGwxG/RkiIhNTv737SkpNLpI2XNkrH4o5Jt5JuSWmZaVJmVqYUfS9amhc1T+q/pr8U9H1QzhjUb0HfB0n9/u4nzYuaJ0Xfi5YyszILHM6j54+kev+rJyESUoXZFaQbiTe0brdzp/x1/vtvSWrQgNb9/CTp3DnNbZculd/W58/NfypER9Ox3asclxAJyfMrTyktM01jm/5r+kuIhNTnzz70wLNn8qAM+fyMQKWSpGXLJMnLi17O01OSFi2ix3M4epSeLFvWLGNITCzcZ/DggfzzAkhSYKAkrVlDf8PJk/SYt7ckZWWZfuzqHDkiSS4u9HqLF5vwwPv3yx/Os2cmPDBjM/TuTZ/xjz9aeyQMY1b01aGO1p5QYBiGYbTQsCEVdTIkQm/v+fMAFZuLiAA2bwb+/Ve24OeHiNb36kWV4C5coGh9//7Ajz9S83Z98fOj19cXLZZ7AGgS2AQ7ru/AHzF/4I+YP/Ls5uzgjPQszfC2UqFEaEAoWlZoSbeglijvbVj1Zl83X2wfuB1tlrXBpUeX0P7X9tg/ZD8CvQI1tmvfHhgxgqLuffrQY2XKkCmiVi3NY77xBkXjb92iYmXmLkEj7Pb+rTcjFkBE5Qg4OzhrbDOl1RSsPLsSa86vwYWHF1DzSfbzbm5UUNKMKBT0HoSHk1V83z7qHLBuHUW//f0huzzu3aPwt4nHpN6D3sPD8P39/IDffqPxv/sulYDo3Rt45RUqhAdQdN7c5UKaNqXo/PXrdPqaDFEMr3dvwN3dhAdmbAa23DOMBmy5ZxiGsUUaNqRlcRP0AFXLArR3HMgPkVs/aZLxufWG1h8Qlvv4eA3f8rjm4zC17VQMDh2MzlU7o0HZBijnVQ6OSppDT89Kh6ezJzpU7oDItpHYPnA7kiYl4cTwE/ix84/4vzr/Z7CYF/h5+GHnmztRqWQlXE+8johfI/Dw2cM8282aJV8Lly5NYr527bzHc3KSrfmzZpHd3JyIgmzpQdSurnPVznm2qeNXBz1q9IAECTMPztTMnzeJZ1s3wcGUmvDtt4CzM7UIrFOH5qBQokS2sodZbPeG2u3zQ9RMUC+aN2MGPWeO/HlthIbS6W6yjy0pidrVAZSCwxRNWNAzjAYs6BmGYWyRsDC6yr1zhwRjQRQ1Qd+9O4nyEycM6+Xt6kpJ4ocOaebWv/EGJYLrorqBgt7bm8KdgEal+1LupRAZHollPZZh04BNODH8BO6Mu4O0T9KQMCEB10ZfQ9KkJGwbuA1Tw6cionIEvFxM1x+snHc57HxzJ8p7l8eFhAvo8FsHJKUmaWzj5UV5zMOGAXv2yJFZbbz1FuU737olayVzcfQoALdHuKckZa9N0APAx60/BgD8fuZ3xF/NLjtvpvz5/FAqqcDc8ePUqz4hgcTp9u0wa2E8Uwl6QC6ad/o0VfUXNG9e+GNbhR9+AJKTyWrSvr21R8OYg9RUuVgsC3qGAcCCnmEYxjbx9JRFQUFR+hcv5Cv8oiLo/fxkdWFMr/mmTTWj9StW0AW+rmi9MR0C8rHda0OpUKKUeylU9qkMB6WD4a9lAJV8KmHHwB3w8/DD6Qen8dHOj/JsU78+8PPP2iPz6ri6knAFKCJtLp4+Bc6dA1BlG1RQoa5fXVQoUUHrto3LNUaHyh2QJWVhz+HstAYTtqwzhLp1aSKiXz+6/913sBtBL6hZkyZ2fv2VIvYdO5ru2BYjMRH4/ntaj4wEHMx7jjFW4vZtWnp4AL6+1h0Lw9gILOgZhmFsFVHxvSBBf+UK1bby8Sla7ZlEUq0htnt1jInWVzVC0GupdG8r1ChdA6v7rAYALD65GLeTbxt9rBEj6Nr52jVTjS4vJ07QV9m9PlW3zy86L/ioNU1SxF44TA9YOEKvjosL8OWXZKrZuhWIL2W+SvfmEPQAzX0NHEgRe7vUwrNnU+pL3bqUP88UTdTt9hZKsWEYW4cFPcMwjK2iTx69ut2+KF3cCEG/f79srzQGXdF6lUre1lDLPSBH6NUs97ZEeHA42gW3Q4YqAzMOzDD6OJ6ewNixJhyYFqKiAChUyKyUt12dNtpWbIuWFVqizBNqCJ8V4G/eAeqgcmWga1daX3veviL0ds+jR8CcObQeGWn+in6M9eD8eYbJA//iMQzD6MLVldRGVBStWwpDBX1RIigIaNSIQrbr1xfuWPlF6wcOhOuFy4j6GYha4gDXKka8hwZY7q3F1LZTARQ+Sj9qFAl7gKz3pj4Vjh4FEHgc6Y4J8HbxRosKLQrcXqFQYEG3BSj/jMLJ/zw+aNoBGcGoUbT8365sQX/5suakkQlgQa+F776jnI369encZoou3IOeYfLAgp5hGEYXDg5A48Z0s6QXNSyMlrdvAw/zVioHUHQFPWBctfuCyB2t//13OLRohcZ3gcbuVeHgYoRCtWHLvaBtcFuTROl9fGTB+uefpg+CHj0KoCpF5ztU7gAnByed+9Txq4PGDpRnv/TBFvx17i/TDspAOnSgOZ6zKcHIcnCiAl4iomgCkpLoBgAVK5rssPZNQgK1qASAadM4Ol/UEecTnwAMkwP/6jEMw9gq3t5A9eq0fvKk9m2Kg6DfuZMqV5sC9Wh9SAgJLkAuYmYoIkL/8KHpxmgGTBWl/+ADqoweFUUlHl55BRg+nFzOCxdS67Pjx4G7d4HMTP2PGxdHN1SndnW67Pbq+CS+AADc8wSGrBuCmPgYA/4i06JU0qRHFhxxwyF7sseEtvs8PeglyWTHtlu++QZ49oy+kN27W3s0jLlhyz3D5IEFPcMwjC7S0+mi8ZtvaN2SFGS7V6lksVAUBX2NGmSRz8gA/vvPtMdu2hQ4dQrpE8fjm3Yu+OYlN6RnGfHZennJPcdtNI8eMF2UvmRJoEkTWo+Opv7rixZRYHTECNJTjRsD5cpRobiyZUlndetGLfKmTgUWLKAsimPHSMRnZmbnz7s/BAKPAQA6Ve2k34AyM3PaOlar1QrPMp6h1+peedr0WZJBg0hsn0k3fR69ht1+wgQgMDC7NUAxJT4e+OknWp82rWjVEWG0w4KeYfLAgp5hGEYXGRnAxIl0y8iw7GsXJOjv3AGePwecnIBKlSw7Lkthatu9Oq6uyPhiGia2TcPExNXIyDLys7UD2z1gmih9Rgawdy+t//UXtb2LjATeeYei9Y0akcZUKmm+6f594NQpmo9ZvBj4/HPg3XeBHj1oYqB8ecDZGRgwAEDVrYBCQmhAKAK9AvUbUHw8RamVSvxvyN8IKhGEq4+vYuC/A6GSTJu7ri8lSgBvvglchOkr3WsI+jVr6A0eO7b4RupnzaLfwMaN5YqETNFFpWJBzzBacLT2ABiGYZgCKEjQC7t91aok6osir74KTJ8ObN5MF+7u7tYeUV6qVQMOHrTpCD0gR+l339iNGQdmYH7X+YU6XufO2bZvLWRlURbC3bvAvXv5L+/fp21fvABQjez2utrVaXD/Pi39/VHayx//vPYPWi5tiY2XN+LzvZ8jMjyyUH+jsYwaBcz6H0XoX0RfhJuJjisEfaWKKmBdHN3ZsYNmTLp1M9Gr2An37wPzs7/DkZEcnS8OPHwIpKXRZ12+vLVHwzA2A0foGYZhbBlRGO/mTWrNpE5Rzp8XhIVR8aPnz4Ft26w9Gu3YQaV7galy6XXh4AAEBJDdvmtXstt/9hnZ7detI7v9nTt0bX7/PnDsRBZKNNgKwLD8edy7R8vsHvQNAxtiYbeFAIBpe6dhw6UNJv279KVWLcCrIQn69LOmj9CHlHqomf4zfrzl3UPWZuZMmglq2pRml5iij4jOBwYW3UlshjECFvQMwzC2TIkSsmDMHaUvDoJeoTCv7d4U2InlHjBdLr2pcHCgEgQZZaKQnPEYJV1Loln5ZvofQAj6gICchwaFDsLIxiMBAG/8+wZuJN0w4Yj15+XRJOhLPI1DakKKSY4pBH01tzu0UqoU4OdH7fHmF85xYVfcu0ezQwDnzhcn2G7PMFphQc8wDGPr5Ge7Lw6CHpAF/YYNthmFFBMuNm65FxQUpc/IysCWq1sweO1gNF3cFHOOzDG+tkABZKmycDHhIlbFrMLkHZPx3qb3AAAdq3SEo9KAbEBhuc+O0AtmvzwbTco1wZO0J/jt9G+mGrZBdOrvi0fK0gCAbT9dNskxhaCvqMz+3KpUAb74gtanTQMePzbJ69g8X39NHSpatAA6drT2aBhLwT3oGUYrLOgZhmFsnQYNaFlcBX3z5hSFTEoC9uyx9mjyIiL0Nt66TpA7Sp+lysKu2F0YvmE4yn5XFp1XdMby08sRFReFsVvHos7/6mD9pfWQjCy89iz9GY7cOYIFxxdgxMYRaLa4GbxmeKHmvJrot6YfZh6ciej70QCA12q9ZtjBc1nuBc4OzhhcfzAAYPeN3UaNu7A4OgLPg+jcPLL8UqHr1qn3oPdLz47Qly8PvP02ULcukJhIor6oExdHPRIBjs4XN7gHPcNohYviMQzD2DraIvTJybKYMbaHur3g4AD07Ekl1f/5B+jQwdoj0kS0rnvwgKL04vOyYaa2nYrdN3Zj8cnF+OfCP3jw7EHOc34efuhTsw8q+1TGrEOzcPnRZfRY1QPtK7XH9FY/AKib73Hvp9xH9P1ojdvlR5chIa+adXdyRz3/egj1D0VoQCialGuCsLJhhv0h4gI/l6AHgHaV2gEADt0+hNTMVLg6uhp2bBNQpmUN4MYBuNy4iKNHgWYGZBPkRr0HvUt8doS+QgU6P2bPpvNi/nzgvfeK9m/CjBlUfKF1a+Cll6w9GsaSsOWeYbTCgp5hGEYXrq7A7t3yuqUREfobN6gwXqlSciussmUpz76o8+qrJOj//Zf6Tjs4mOSwro6u2D1od8660VSrRoL+yhW7EPTqFe8fPHsAXzdfvBryKl6v8zraBrfNsb0PazgMM/bPwPdHvseu2F1ofi0MXb6cgcGhg3Ej5RHOxmqKd/WJAXUCPAMQGhCaI95DA0JR1bcqHJSF+BwlCTh6lNbD8k4E1ChVAwGeAbifch+Hbx/OEfiWxLV+DWAFUAOXMHdu4QS9Rsu6O2oRegCIiKAq9xs3Ah9+SOkpRZHbt4FFi2ido/PFDxb0DKMVFvQMwzC6cHAAwsOt9/olS1Ku7LVrwMmTFIkrLnZ7Qbt2NHHx4AFw5AjQsqVJDuugdEB4cLj2J0+fpoinry8JxgYNgMqVqcl6bqpVAw4csIvCeIJfev6Cn0/8jJYVWiKicgScHPJWjfZ28caMiBkY3nA4puycgtXnVmNT5kRsOj4ROJ73mAooUKN0DQ3xXj+gPgI8A/JuXFiuXKE0B1dXedJLfSwKBdpXao+VZ1di943dVhH0IlJeA5fw5l/A06c0XBcXWor1oCBg5MiC56k0BP1ttQi94NtvgS1bSNRv3256J0tiIpCQINeMsAZffUXV/cPD6TeBKV5wDj3DaIUFPcMwjD3QsCEJ+hMniqegd3YGXnkF+P13st+3aUOW21atgNBQSlg2JStXAkOHZjdIV8PLi14vLAxo1Ajo0wdwc5Pz6O2kMB4ABJUIwpftv9Rr20o+lbCqzyqMbjoaH2z9AFFxUXks86EBoajjVwcezvk0pzc1Bw7QsnFjUsVaaBfcLkfQW4VsQR+ivIzMDBU2bMi/dFFgIH2d8kND0B/PFaEXr/Xee8CPPwLjxgGnTpn2vOjRAzh4kCYNrJH2cvMmsGQJrReHWgGMJs+f04QSwDn0DJMLFvQMwzC6yMgguzcADB9unf63DRsCf/5JEXqg+Al6ABgxAli7li7q/vlHbmPn6UmF81q1IpHftCng7q7XITOyMvDzCfpshzccDidJAUycCHz/PW0QEUHuiJMngTNnKMS6fz/dACAmhvph21Ev+sLQOKAFBqYeQU+vp/hgpAdcXUyT+mAUQtC3apXvJu0rtQcAHL1zFM/Sn1luskFQuTLg6Ai3zOdYMycOj9wrIDWVCrSnpdFy7176Om3ZoqegD1LJlnv1CD0ATJ0K/PYbfS+XLAHeecc0f8fDh/J3fvhw4OxZOu8syfTp9Fv80ks0occUL8QJ4OVVPNLMGMYAWNAzDMPoIj0dGDWK1gcPtp6gB+TCeMVR0LdsSWL++HESFwcOUMQwKYksxtu303aOjvR+iQh+q1ZUd0AL6VnpGLWZPtvB5brA6Y235Er6H39MkUDhg87MpPf95Elg82Zg1SqyNxcjQZ+eDrz/vgKAN0a/A0B7YNwy6CHoK5WshKASQbiVfAsHbx9ExyoWbnHm5EQTQpcuoVfNi0CHCnk22bIF6NwZ2LaNygLklxYu9Ex1n4ckbBWKvMUAfX2ByEhgzBjg00+B1183jfhR7y5x4wadG3PmFP64+hIbCyxbRuscnS+enDtHy1q1uHYCw+SC29YxDMPYAyJH+Pp1ipYJa3dxEvQAWatbtgQmTyYx/egR5brPm0fipVw5Et5Hj1JOcc+eQOnSQO3aFK38/XcSJNp6iLVuTcLF0xNYswb48kvNpGZHR6BOHeDNN6kwn0IBnD9PbbSqVKFtEhLk3mKM+YiPp8kThYLcGfmgUCjQLphyrXfF7rLU6DQRFedFIctctGlDGSW3bwOXC2hXLwR9Zafs/PmyZbVPLr77Lr3mw4eUc24KdmW/d40b03LuXODQIdMcWx++/JLO644dTVY/g7EzYmJoWaeOdcfBMDYIC3qGYRh7wMeH7LsA8PffFKFzd9fMoS2OKJVAvXqUO/zHH6SKYmOBX38la3DNmrTd+fOUNjFwIFCpEhVV6t8fWPSzfKw7cUD16jQZ8OqrBb9uqVKya2LHDrKBBmQXfrOjPHq75eBBWtapQ+dGAQjbvbXz6PMT9O7usslAmExyo96DPlClJX9eHScnmswCgB9+oEnAwiIE/SefkEtJkoC336acAXNz7RqwfDmtmzE6v+b8Gvxw5AezHb/Y8c8/wNatpjseC3qGyRcW9AzDMPaCEJArVtCyRg3tFdeLMwoFVQ0bOBBYuJCE/MOHlHs/fjzl1zs6Ug7yH38AH4yT9+3SGYiKIkunPojCYEKFFRPbvU0g7PZ6RGtFhP743eNITk0256i0o0PQA3m/SrlR70Hv+lBLhfvcdO1K9R/S06kmRGGIiyPrgFJJdoLvvgP8/Sn9ZPr0wh1bH774AsjKoryEwvT9K4DnGc8x4J8B+GDrB7iVfMssr1GsWLwY6N0b6NSJ0j8yMgp/TBb0DJMvfCXIMAxjLwhBL6KTxc1ubyylS1OF7m+/pZZ3SUnAzp0U7VNvfbVqtWH5xkKF7dhBEUs7rHRvt+iRPy+oUKICqvpWhUpSYf+t/WYemBYMEPS7d2vXPgX2oNeGQgHMnk0ifM0aYN8+Q0ctszvb2dCwIbXQ9PWlFBcA+PprSnkxF1euUJE/gGoDmImDtw4iLSsNAPDw2UOzvU6x4NAhckwJfvyRJpcePDD+mC9eyL+rtWsXbnwMUwRhQc8wDGMv5O61zYLeODw8gPbtgc8+AzZskB831O3QogX5pR88oKrfHKG3DM+fy90e9BD0gByl3x1rBdu9OE9v3QKePdO6SVgYZXE8fUomkdzo7EGvjbp1qfUiQG3sVCpDR04Iu3379vJjvXvTLTMTeOstWpqDzz+ncXftCjRpYp7XgGZ9heQ0K7g4igp37lC6UkYGfT/+/ZfSkfbtowkhbV9ufbh4kb4Hvr5yahPDMDmwoGcYhrEXWNDbFi4ucvus7dtZ0FuKqCgSkOXLUy0EPcgR9NbIoy9dmoQIkO93Q6mkbmyAdtu9wRF6wRdfkKA6cUKOdBuKEPTqbhaACkOWLEmTK7NnG3fsgrh4EVi5ktbNXNmleqZhAAAgAElEQVR+Z+zOnPWkVC5qaRSpqSTmHzygyaRffqGipFFR5FKJi6PCo0uWGH5sdbs9V7hnmDywoGcYhtGFiwtVVN+4kdatRalS2Vf02bCgLzQuji7Y2G8jNvbbCBdHIz5b9eTnYmC5t4lTQT1/Xs+L+3aVSIxG34/G4xePzTWy/BF5v9OmUT64FsRXadu2vM8ZFaEHAD8/KmQHAB99lK9DIF9iYymB39ExrxsiIAD4/ntanzq14BL9xiCi8927y+lGZiApNQkn7p3QuM8YiCRRF5Fjx2jyau1a6hYC0P+pqCgS9+np5Bp5911a1xfOn2eYAmFBzzAMowtHR7J8du1K69ZEXNgqFHJEmDEaR6Ujulbviq7Vu8JRacRnK1TYvn1yxLQIt66ziVPBgPx5QYBnAGqWrgkJEvbe2GumgRXA9OnUm04UZ9SC+CpFRQHJuVzfOYI+SEWRTkD/DhdjxlBnh7t3gVmzDBu3iM43a0apKrkZNIhayaWmklAz1tafm/PngVWraN2MufMAsO/mPqgkedws6I1gzhzqLOLgAPz5p9yRReDtTbUcvviC/nctWAD06aP/8VnQM0yBsKBnGIaxJ4SgDw4G3NysOhQGdIEZEEBFm86cod7gANvuzUVWFnD4MK0bIOgBK7eva9VKbr02Zw61k8tFxYrUNTErS65DJxCCvopXPOUnK5Xyd00XLi6ykP/mGznCrw/a8ufVUSiom4SHB7B/P7V8NAWff05R3169qMCAGVHPnwdY0BvMzp3Ahx/S+rffyrkjuVEqyS2ycSN9bzZsAOLj9XuNc+doyYKeYbTCgp5hGEYXGRmUD/jLL6Zpv1MYXnmFIn3dull3HEWEjKwM/BL9C36J/gUZWUZ8tgoFVXAGioXt3uqnQkwM8OQJ5YXXrWvQriKPPreAsxivvw7MnEnr48ZRn+5caGtfp96DPkiZnT8fEED95vWld2/KX37xApgyRb99JCn//Hl1goOBtm1pPTpa/zHlR0wMRXkBs0fnATl/vpovOZ6s0trQXrl+HXjtNZqFGjSI3CC66NJFbg0qJucK4skTuW8jV7hnGK2woGcYhtFFejowZAjdDMn7Mwd16gCPH8u5q0yhSM9Kx5B1QzBk3RCkZxn52aqrsCJeGM/qp4Kw2zdvTvZeAwgPDgcAnHt4Dg9SCtFCqzBMmACMGEFiecAAaqOohjZBr96D3i3BgPx5dUQbOwBYsUK/auMXLwL37wOurrr7v4vJlbNnDRuXNqZNo/enTx+gXr3CH68AHqQ8QEw82bl7hfQCACSlcYReL1JSqB3o48dA48Zko9e3YF3z5rQ8dEj3tufP0zIwUC4uyTCMBizoGYZh7A0PD4PFDGNGRIT+5EmgXDlaL6KC3uoYkT8vKOVeCvX96wMA9tzYY8JBGYBCAcydS0UIUlPJcaPm5ggPp1P7yhVZyGstiKdv/rw6jRpRFBUAPviARHNBCN9/y5Yk6gvCVIL+9Gng77/pfZo6tXDH0gPxPajvXx9VfKsAYMu9XkgSMHgwuSkCAqg9na7viDotWtBSnwg9588zjE5Y0DMMwzBMYQgMJCuoJFHUCiiylnurc/AgLY0Q9ICV29cJHB2p4FvDhlRAsUsXWgIoUQJo2pQ2E1F6rS3rDI3QC776CnB3p8iosLXnh678eXXUBb2uiYKCEO3pXnvNIgJO2O1fqvQSSrqWBMCCXi+mT6cid05OtBQTmfoiIvTHjum2+rCgZxidsKBnGIZhmMIivNJCfXGE3vTcukURakdHoEkTow5h1cJ46nh6UnGwihXpu9KjB5CWBiBv+zqTRegBmnyaNInWJ06knHptqFRyhL6g/HlBSAh9LsnJhhXdU+fUKYr0Wig6D8j1FNpXap8j6DmHXgcbNgCffkrr8+fL0XZDqF6d7POpqeTKKAgW9AyjExb0DMMwDFNYhAo7fpyWjx4BiYnWG09RRNjtw8K0t1DTgzYV20CpUOLyo8uIexJnwsEZQUAAsGkTULIkRcw3bgQgf5V27qRaYyaN0ANUkbx8eZogya8Wx5kzlBvt6UlWfV04OwM1atC6sbZ7UQCvXz+gZk3jjmEAN5Nu4lriNTgoHNC6YmuO0OvDhQtU+wEA3nuPWhUag1Ip12XQlUfPgp5hdMKCnmEYhmEKS9u2ZD+9fRvw86PH2HZvWgqRPy8o4VoCDctS60erR+kBqvb92mu0nj0Z1KQJte1+/JiC1iaN0ANkuZ8xg9ZnzKDCd7kR0fk2bfSvpl+YPPoTJ4D160noffaZ4furkZ6Vjmfpz3RuJ6LzTco1gbeLN0q4lABg44JekoDx44H33y9caoMxJCWRk+TpU/peaGm9aBD65NE/fAg8yC5gKSrjMwyTBxb0DMMwDFNYPDzkC1Rvb1qy7d60FDJ/XpCTRx9rA4IeABo0oOXJkwBIPwuX+/btaoI+SAXEZbsKChOhB4D+/akyeUoK9QbPjSH584LCCHphsR8wQI70G0FSahIa/twQQT8E4VbyrQK33XVDttsDyInQP0l7ApWk+n/2zju8qbL9458kbdLSUlYpu0DZZcreG0RcDEEUERTFV3Ajjt+roqiouFHUV5GhgkxZMgSRJSIgs6yCZc/SlrZ0pU2T3x9PT5K2SZu22Tyf68p1TpMzntPTA/k+931/71KPwaWcOiW6FXz5Jeze7b7z5uaKzIlTpyAyUhgXlqRtoi2UOvqiBL3Sfz4qqtRZORLJrYAU9BKJRFIcOp0wkFqyRKxL/AZdgI4l9y1hyX1L0AWU8d4qudJKg3Y/FPQeexSSky1CsVu3Mh2qT/28fvRnPdSPviC33SaWBw6Yo67Kn9KyZZYe9PWCr4HBIKLYNWqU7ZxqtSXdfs6c/P3jDQbYtk2sO1I/r1BaQb9nD6xdK+z9ldrsUpBrzGX0L6M5En+EpMwk/m/z/9nd1mQy5aufB5G9AWDCxE39zVKPw6UoxgoAP//svvP+97+wYQMEB8PKlaKHYlnp2FH8HZ4/b5moKohMt5dIHEIKeolEIimOgAAYMUK8AgI8PRqJEwlQBzCi+QhGNB9BgLqM91ZRYUoK8+XLZTueF+KxR2HXLiF2GzaEatXKdKjukd0JUAdwNvksZ26ccdIAy0DLlkLMXr9u/ptR/pTygvZUrQrlkvLq52vUcM4vv1s3uP9+8Xu1bmO3b59Iq65UCVq3Ltl1gOhfr0xqOYISnR8zBho1cny/Arz2x2usO7UOnUaHChULYhaw59Iem9ueTDzJ5ZuX0Wl0dK0jMmuCAoIIChCt17w27V5pfQBiVi031/XnXLQIPvhArH//vWUCqqyEhkKrVmLdXpReCnqJxCGkoJdIJBKJxBm0aycMzvLcyklM9Ox4/Akn1M8rhGpD6VRL9IabsXNGmY9XZoKDLSZweQq+USOR2azgtPr5gnzwgUi12LoVVq0S7yn18717i4kGR6lbF8qXF2I+NtaxfXbtEpFfjcZ26r+DLDqyiPd3vg/AnHvnMKb1GAAmb5yMyUatudKurltkN7OIB7y7jj4nx3JvAgLExKGSSeEqDhyARx8V6y+/LNLunYlSpmTPGE8R9M2bO/e8EomfIQW9RCKRFIfBAEuXipfB4OnRSJyIwWhg6dGlLD26FIOxjPdWo8lfc5yUVLbjeSEeexScVD+v8FrP11Ch4pt93zD3wFynHLNMWKfdIzq3KVF6cKLDfUHq1oUXXhDrU6aInuClqZ8HMWglkupo2v20aWI5bhw0aFCy8+Vx4MoBHl0lROeUrlN4sOWDvNv3XYIDgvnz/J+sOLGi0D7mdPt6+a/Rq53ud+8WmRNVqsDYseI9V6bdx8fDkCGiteEdd4je886mqDp6k0lG6CUSB5GCXiKRSIpDrxdO1CNHWqKvEr9Ab9AzctlIRi4bid7ghHtrrcL8MELvkUchO9tiAOYkQT+o4SDe7P0mAE+ufZJ/Lv/jlOOWGsUYL0/Qgw1B74oIPcCrr4oyhn//FYZrSjZEgfr5qVum0nl2Z66nX7d/rJLU0d+8aUkhf/nlUgwc4tPjGbJ4CJmGTAY1HMR7/YR7f+2w2rzY9UUAXtr0Etm52eZ9jCajucNBv6h++Y5nV9CvWQNzPTzxo9TP9+9vaR23fLl4PpxNTo6oqzl/XqSLLFxYsmwNR1EE/b59oie9NZcuQUqKOG8ZjBIlklsBKeglEolEInEW1iosIcFz4/An9u8XX/bDw6FxY6cd9rWer3FPk3vQ5+oZtngY8enxTjt2iVEi9ErRPNCvnwh6gwsj9CDS5N95R6y/9pqIyEZE5GsTZjQZ+fTvT9l9aTdf7vnS/rFKIuh37BA14A0alKp2Pjs3m/uW3Mf5lPM0qtyIhcMWolFbROdL3V6iemh14m7EMWvPLPP7h64eIikzifLa8rSv2T7fMRVBn6JPsbx54wYMHy5Sz63uj9tRJj8GDhRt42rUEGP77Tfnn+v552H7dvG3sWqVKCVyBVFR4m8tJ6fw71aJzjduLM1oJZJikIJeIpFIJBJn0aCBJYIqBb1zUCLG3bpZFK4TUKvU/DDkBxpXacyF1Avcv+z+spddlJY2bcTy/HlzZkd4uMXQv3VrXBehB3jkEXESxWStb998v+tTiae4mS2c37/+52uyDFm2jlIyQV/a1P48ntvwHDvO76C8tjyrRq2iUnClfJ+HakN5u8/bALy9/W2SMkUJjJJu37Nuz0JGmDYj9KtWWUz+liwp1VjLzI0bohsAiElDjUYYGoLz0+6//x5mzRL3f8ECi7+DK1Cp7Kfdy3R7icRhpKCXSCQSicSZ9O8vltnZItopKRvKF/0ytquzRYWgCqy8fyWh2lC2nt3Ky5tKl/pd9oFUsNSQW7WQW7RIeMZ164brIvQgBOInn1h+LiCy913ZZ16/nnGdRUcW2T6OIujPnYPU1KLPWQZB/+2+b/n6n6+Fm/2wBTSralt0PtLmEVpGtORG1g3e3ibEvdKusF/9foW2t2mKt3SpZX3xYks3AHeyZQsYjdC0qeX+KwZ1q1ZBerpzzrNrFzz5pFifNg3uvts5xy0Ke8Z4UtBLJA4jBb1EIpFIJM6kvVUarx8a47mdQ4fEsl07lxy+WdVmzB8yH4BP/v6En2Pc2N/bGhtp97Vqwe23IyLnSq9uV0ToQQjriROFaBwyJN9H+6+IMYXpwgD4fPfnNt3jqVwZatYU64ogs0ViomXionfvEg3zz/N/8tS6pwB4u8/b3N3EvujUqDV8PPBjAL7c+yXHrh9j+7ntgKX/vDWFIvTJyZZU98BAOHsW/vGA34IyBuuSng4dxCRQRoao8S8rly7BsGEiG2H4cNF73h0oEfq//so/WSIFvUTiMFLQSyQSiUTiTKKiLOt+aIznVtLSIC5OrCvRXxcwrNkwXu3+KgDjV4/n8LXDLjuXXQo43ecjPl60FVCrRe20q5g1C44fF43vrVAi9G/0fIPggGAOXj1oFsaFcCTtfts2Id6io6F6dYeHdyHlAsOXDCfHmMOI6BH8X4//K3afAQ0GcEfDOzAYDQxdPJS07DTCy4XTslrhvydzDX1WXg29km7fvLkQueCZtHvFEG/gQMt7KhWMGiXWy5p2n5UFQ4eKVngtW8K8eU4tbymS9u0tbfjOnRPvGY1w7JhYl4JeIikWKeglEolEInEm1oJe1tGXDSVKV6NGIZHpbN7u8za3N7idTEMmQxcPNddcuw3F6d6W8ZpSP1+jhhA/bsRoMpoj9AMaDODh1g8DIkpvE0cEfSnS7TNyMhiyeAjx6fG0qtaKuffOReWg6PxwwIeoVWpOJp4EoE+9PqhVhb8CmyP0+rwIvZJuP2KEaO0AQtC7M+0+Lg5Onxb3vVev/J8paffr14s6+9IyaRLs3SsyLFauhNDQ0h+rpAQHWyazlPKaM2dEuZJOV+p2hhLJrYQU9BKJRFIcWq1oWTR3rliX+A1ajZa5985l7r1z0WqcdG/r1rWsnz3rnGN6CW5/FJR0+9atXX4qjVrDwuELqV+xPqdvnGb0L6PJNea6/LxmFFFz8qTITLDGlfXzxRCXFEeqPhWdRkez8GY80+kZAFbFruLMjTOFd3BE0G8RbeMcFfQmk4nH1zzO/iv7qRJchVWjVhGiDXH4GppHNGdC2wnmn22l24PwVIC8lPvkZEtkfMQI0Ys9NFQYFyptFN2Bkm7ftatwnbemeXPx+87JgV9+Kd3xr1+HOXPE+pIl+Sck3YVSR68IemUiLzraNe3yJBI/Qwp6iUQiKY7AQBg3TrwCAz09GokTCdQEMq7NOMa1GUegxkn3NihIvABOnXLOMb0Etz8Kh/NS31u1csPJoHJwZVbcv4LggGA2/LuBqVunuuW8gOgFX7OmiP4eLpDy70qH+2JQ0u1bV29NoCaQ6KrRDIgagNFktN3CzlrQ24pkX70q0qlVqsIRZzt8vOtjFsYsRKPSsGzkMupVrFfi63irz1uE6cLQqDQMiBpgc5t8NfSrVwuhHB0tXkFBcO+9YsPFi0t8/lJjq37eGiVKX9q0e6WkpU4d0SvRE1jX0YOsn5dISogU9BKJRCKROJsKItLHGRsRTInjuFnQgxCus++ZDcC7O95lxfEVbju3LWM8wKMR+n2XhaBvV8NiSvhc5+cA+P7A96RlF8gmaNZMRFVv3IDLlwsfUInO33abSPEuhg3/buDl30X3gc8GfUbver1LfhFAREgEfz36F3+M/YMGlW2nceerobdOt1dQ0u6XLhV13q7GYIDNm8W6df28NUr7ui1bxGRJSVH+japfv+T7OgslQn/woHDsl4JeIikRUtBLJBJJcRgMsHateBk81Kda4hIMRgNrT65l7cm1zu1BXqWKWCrO5H6CWx8F60i1GwU9wIMtH+S5TkK0PrzyYY5fP+6eE9szxvNghH7/VTG5YC3oBzUcROMqjUnRpzD/4Pz8OwQFQaNGYt1W2r1SP9+nT7HnPpl4klHLRmE0GRl/23gmdZhUqmtQaB7RnJ51e9r9XBH0uTeS8qfbK9x+O4SFiee6YJs1V/DPP5CSApUq2e/yEBUFnTqJCYbSGPZ5g6CvU0e0dMjNFdcsBb1EUiKkoJdIJJLi0OvhrrvES6/39GgkTkRv0HPXz3dx1893oTc48d4qTuTXrjnvmF6AWx8FpZd5YKBopeZmZgyYQa+6vUjLTmPo4qGk6ovpq15KVseuZtzKcWTkZFiM8QoKeg9F6E0mk9kQr11Ni6BUq9Q83fFpQJjjGU0FotVF1dE7aIiXqk9lyKIhpOhT6FK7C7MGz3LYBK+0KH3oex5OhuxskW3QvLllA53O0tLPHW73yqRCv35F15IrafeLFpX8HIqgr1ev5Ps6EyXtfts2OHFCrEtBL5E4hBT0EolEIpE4m8hIsSyL8/StjhKdj472iHdFoCaQJSOWUDusNrGJsTy84uHCwrWMmEwmJq2bxPxD81l+bLklQn/kiBCUCjYi9MevH2f+wfnOzSwpwOkbp0nOSkar0dK8avN8n41rM44KugqcSjrFhn835N/RnqA/d044tms00KOH3fMaTUYe+uUhjiccp1b5WiwfuRxdgM4Zl1QkSoR++JG82n/r6LyCkuK+bJmIKLuS4urnFUaOFC0Nd+0quRGnN0TowZJ2/8MPIv2nfHmPlJhIJL6IFPQSiUQikTgbxSn65k3PjsOX8VC6vTURIREsH7kcrUbLqthVTN8x3anHP3ztMBdTL5rXqVtXpFfn5MDRo2Kj3FxLLbqVwBm3ahzjVo1jwpoJmFzURk0xxGtVrVUh08hQbSjjbxsP2GhhZ0/QK/XzHTsWdmy3YuqWqaw5uQadRseK+1dQo3yN0l9ECSgXWI7K2Rpuz/OJsyno+/eHihXhyhX480/XDSY11eL6Xpygr1EDevcW6yWN0nuLoFci9IpJX4sWwjhRIpEUixT0EolEIpE4GyVFXK8X4kxScpSWdR4U9AAda3Xkq8FfAfDGljdYf2q904699tRa83pMfIwQMAXr6K9dExFLtRqqVwcgOzebA1fE53MPzjWbxjkbW4Z41jzV8SnUKjUb4zZy7PoxyweKoD9+PL/ZggPp9kuPLuWdHe8A8N3d39GhVofSX0AJUalUjDwdjC4X9I3q50+3V9BqYehQse7KtPutW8VkTsOGjont0rjd5+aKNnzgeUF/222ipEFBpttLJA4jBb1EIpFIJM6mYUPLuvKFWVIylAi9G3rQF8f4tuN5ot0TmDDx4C8P8m/Sv0457q8nfzWvx8TnRbMLOt0r9fM1a0JAAACxCbHkGHMIUIufP/zrQ2bsnOGUMVmjROjtCfr6lepzbxPRym3m7plWH9SHkBAxoaW0bjSZihX0h64eYtyqcQC80PkFxrQeU/aLKCFKun38Hb3sR4it0+5d5Q6ppNvbc7cvyLBhYnn4sOgt7wgXL4rxBwaKvy9PotPlN/6zNZkikTiB1bGrqftZXZ5d/6ynh+I0pKCXSCQSicTZhIdb1pUUUonjZGRYhKCHI/QKnw/6nM61O5OclcywxcNIz04v0/ESMhL4++Lf5p8v37xMYkZiYWM8G/Xzh66J7IUutbvw0YCPAHj595eZvX92mcZkjT1DvII820l8Kf7h0A/subRHvKlWWwSZknZ/6pRwh9dqLenVViRkJHDvonvJyMlgQNQAPhjwgdOuxWFSU+lxIgOAM/3b29+ub1/RySI+HrZvd81YFEO84tLtFSpXtnh3nDzp2D5KvX3dukWb7rkLpY4eZIRe4jJirsVwPuU8SVlJnh6K05CCXiKRSCQSZ6O0rQORdiwpGUePiohuRARUq+bp0QCgC9CxfORyqoVUIyY+hvGrx5epdn39qfWYMNG6WmvqVxTpzjHxMZYI/cGDIiXahsP9oatC0Leu1prJXSfzSrdXAHji1yf45fgvpR6TNWeTz3Ij6wZajZYWEfbFVc+6PelSuwuZhky6ft+VN7e+SU5uTuE6eiU637UrBAfnO0ZObg4jl47kXMo5GlRqwKL7FpmzD9zKr7+iM5g4UQUuRFawv11goCUivnix88dx7pwQ5RqNQ+39zDRpIpaxsY5t7y318wrWEz1S0EtcxJHroi1ii6r+8zcmBb1EIpEUh1YLX34pXlqtp0cjcSJajZYv7/iSL+/4Eq3Gifc2ONgS8fIjQe+2R8FL6ucLUrN8TZaNXEaAOoDFRxfzya5PSn0spX7+rsZ30aqauM7D1w5D48ZQrpwlS0GJ0FsL+rwIvbLf9H7Teey2xzCajDyw/AH+OPNHqceloKTbt4xoWeSzoVKpWPvgWh5o8QC5plze2vYW3ed2Jz4qbyKmoKC3kW4/eeNktpzdQqg2lFWjVlE5uHKZx18qli4Vi+aQkl1Mm8KRI8Vy+XLnp90r6fadOkGFIiYWCtK4sVg6GqH3NkHfs6cwhWzVSkzmSSQuIOaa+DepZbWWHh6J85CCXiKRSIojMBAmTRIvD7TPkriOQE0gkzpOYlLHSYVcvMtMaKhY+lHKvdseBS+qny9I98jufHb7ZwC89PtLpRLPObk55lZvdza6k5YR4otlzLUYMRGkXPeBA5YIvY2U+9bVxXYqlYpv7vqGYc2GkZ2bzb2L7uWfy/+U6voUFEO8tjXaFrttpeBKLBy+kIXDFlIxqCJ7Lu1h7OmPATDFxIDRKEzeoJCg/37/93yx5wsAfhr6E80jPFQ7ffMmrBeGh0ujITkruejte/eGqlUhMdHi3u8McnPht9/EuqP18wq+HqEPD4djx0QveulwL3EB2bnZxCaK56OozCNfwwP5TBKJRCKR3AJUrAgpKSJ9VlIyvKBlXVFM7DCRvZf3Mv/QfO5fdj/7JuwjskKkw/v/deEvUvQphJcLp2OtjlxIFVH4fMZ4u3YJY7wCEfqraVeJT49HrVLn+0KqUWtYOGwhgxcO5o8zf3DHgjvY8cgOmoY3LdU1FmeIZ4sHWj5A98jujFs1jr3pYqJDdfo0Vzevovr16xhDynGiXgjpl/aSnpPO+ZTzPLn2SQDe6v0W9za9t1RjdQq//gp6PfG1KhFT7QaDihP0AQEwfDh8841Iu+/fH9LTRbu5lJTSL9OtvBkcrZ9X8PUIPZg7OUgkruBk4kkMRgNhujDqhNUpfgcfQQp6iUQiKY7cXNixQ6z36OEd5kESp5BrzGXHeXFve0T2QKN24r2NiBBiXukh7ge45VEwmbw25V5BpVLx9Z1fExMfw/4r+xm2eBg7HtlBcGBw8Ttjcbe/o+EdaNQac+r8kfgjGE1G1Nat6wpE6A9fE5MdjSo3olxguXzH1QXoWHn/Svr+0Jd/Lv/DwB8HsvPRndSpULIvriaTySLoizDEs0WdCnXYNGYTM3fP5MrXz1MjDf54YRgPAr/VyGDw7NsK7TOs2TBe6/laic7jdPLS7WP7tATV9uIj9CDS7r/5BubMgXnzxAPiLLp0gY4dS7aPEqH/918xluIeUG8U9BKJC1HS7VtEtEDlR1kgUtBLJBJJcWRlWYyJ0tJEOyaJX5BlyKLPfHFv015NI0TrxHurtIFKT4fkZBGx93Hc8ihcvCh+XwEB0KyZC07gHIIDg/ll5C+0/649+67sY+K6icy5Z45DXxKV+vk7G90JQMPKDdFpdKTnpHPmxhkaKE73+/eLVHAwR+jNhnjVbZcjlNeVZ92D6+gxtwexibEM/GkgOx7ZQXi5cJvb2+JcyjmSMpMIVAeaywFKglql5rnOz5HWbgls28WIvBb1O6I0VA6uQEhgCCHaEMoFluO26rfx2aDPUKs8WAVqNJrT3C8O6ARntpOiTyl+v549hYiOjbWIebVa1L2HhZV+GRaWvye7o9SpI/bT68VkYlSU/W31estkoxT0kluEI/H+Z4gHUtBLJBKJROIarE2dzpyxuJdLikZJt2/atHSixo3UrViXxfctZsCPA5h3cB4danZgYoeJRe5z+sZpjiccR6PScHvD2wEIUAcQXTWaA1cPEPiBuTYAACAASURBVBMfQ4Pmd4gJjRs3xE4ajTkV2WyIF2E/e6FqSFU2jtlItzndOJFwgsELBrP54c2U15V36LqUdnUtIlqgCyj9PQht1wW27SLQKH6e/u7fTG9fRDs4T3HxojAhDAwkt3k0nHGghh7Efdm/H86ftwjycuU8V/+t0UCjRnDkiJhkKErQnzsnsmFCQvK32ZRI/Bizw70f1c+DNMWTSCQSicQ1WLeuO33ac+PwNby8fr4gfev35YP+omf6sxueZe+lvUVuv/akiM53j+xOxSBL1kY+p3udztLHHUS2R176dEFDPHtEVohk40MbqRJchb2X9zJ08VD0Br1D16QY4pWkft4mLa2i+xUqeO+kllJz3qABYaHCYd8hQQ9CwDdtKu5RSIjnzdyUOvrijPGs0+09PWaJxE34o8M9SEEvkUgkEolrqGzVeksKesfx8vp5W0zuMpn7ou/DYDQwfvV40YfdDtbt6qwxO90rxnhtrdzl8+rn9QY9JxJOAKIHfXE0q9qM9aPXExIYwuYzmxn9y2hyjcXXeSv184443BeJtaDv3dt7/UcU8du4sXmSxWFB720odfTFGeMpgr5ePZcORyLxFtKy0ziTLP7um1f1UDcNFyEFvUQikUgkrkBG6EuHF7ess4dKpeKrwV9RJbgKMfExfPTXRza3S8tOY8tZ0eJMqZ9XUCJGSgQpXzQ7r37+2PVjGIwGKgVVonZYbRyhQ60OrBy1Eq1Gy/Ljy5m4diImk8nu9mUxxCtEdLSoKQeb/ee9BkX8NmliFvQpWQ7U0HsjpYnQSyS3AMeuCzOPaiHVqBpS1cOjcS5S0EskEolE4gqsBb3y5VlSNFlZFiHiQxF6EHXrn97+KQBvbXuLU4mnCm2z+fRmsnOziaoUVaidnJJyfyrpFJk5mTYj9IrDfevqrUvk0Nw/qj8Lhy1ErVLz7f5vee0P+47yF1IvkJCRQIA6wDwmQJjznT/v8DkBCA6G7t0hKAjuvLP47T2FIuhvxQi9Hwj6XGMuD694mFd/fxWD0eDp4Ui8FMUQz9/S7UEKeolEIpFIXINMuS85R48Kx/EqVaBGDU+PpsQ81OohBkQNQJ+rZ8KvEwpFwpV2dXc2urOQIK8WUo3wcuEYTUYRSWrd2lLbrDjcK/XzDqTbF2R49HC+ufMbAKb/OZ1Pdn1iczulfr551eYEBQSJN00m0RO9USOIiyvZiVetghMnoEGDEo/ZbVil3FfQVQBAn6sny5DlwUGVEkXQX7yYv6d9QfxI0P9z+R9+PPwj7+98n+FLhosJMYmkAOaWdX7mcA9S0EskEknxBAbCjBniFRjo6dFInEigJpAZ/Wcwo/8MAjVOvrfWEfqzZ53bo9pDuPxRsDbE80GjLpVKxf/u+h/lAsux9exW5hyYY/7MZDLZrZ9X9s1XRx8aakmfLiDo80XOS8Dj7R5net/pAEzeOJn5B+cX2kZxuM9niLduHezeDdnZsG1byU5asSLUrVuq8boFvV48nwBNmlBeVx4V4m/PJ6P0lStb/u05VThLxIwfCXollRpgdexqBv40kBuZNzw4Iok34q8O9yAFvUQikRSPVgtTpoiXVuvp0UiciFajZUq3KUzpNgWtxsn31jpCn5MDly459/gewOWPgg/WzxekfqX6TOs9DYAXN73I1bSrABy4eoAraVcICQyhV91eNvfN53QP8P778PDDMGgQJpPJ0oO+FBF6hVe6v8ILnV8AYPzq8ayOXZ3vc5uGeO+/b1lXTAv9hbg4kYEQFgYREahVaioEiSi9Twp6sETp7dXR37wJiYli3Q8E/fGE4wD0iOxBBV0F/jz/Jz3n9eTyzcseHpnEm5Ap9xKJRCKRSEqGtaAHWUfvCD7Wss4ez3Z+lnY12pGclcwz658BLO3qBjQYYLe3eyGn+yFDYP58CAnh8s3LJGYmolFpaB5ReodmlUrFhwM/ZGzrseSachm5dCTbzoqou01DvL/+gj//tBzA3wS9Vbq9khXiN8Z49urolYyEypXFRIaPowj6US1Gsf2R7dQIrcGR+CN0/b4rJxOL8RKQ3BIkZCSYJ1ejq0Z7eDTORwp6iUQiKY7cXNi7V7z8IG1aYiHXmMveS3vZe2mvQ+28SoRWC+XLW372gzp6lz4KJpNPtqyzRYA6gO/u/g6NSsPSY0tZHbuaX09Z6uftUcjp3gol3b5JeBNLbXspUavUzL5nNvc0uQd9rp57Ft3DgSsHuHTzEvHp8WhUGksWwAcfiGXHjnkDOSTulb9g5XCv4DfGePYi9H6Ubg+WlPtm4c1oVa0Vf43/i0aVG3Eu5Rzd5nRj76W9Hh6hxNMo0fn6FesTqg318GicjxT0EolEUhxZWeLLbMeOYl3iN2QZsug4uyMdZ3d0jQGWnxnjufRRuHJFpAGr1aLdmY9zW43bmNxlMgBP/PqEWVQMbjTY7j7NqzZHhYpr6deIT4/P95nZ4b4M6fbWBKgDWDR8ET3r9iRVn8qgBYNYdGQRICJYwYHBcOwYrF4tItezZwvjhOTkkrvdezNWDvcKijGezwr64iL0fiToM3MyOXNDXE+zqs0AqFexHn8++iftarQjISOBPvP7sClukyeHKfEwiqD3x/p5kIJeIpFIJBLXIXvRO46Sbt+kiWh35gdM7T2VqEpRXE27igkTbWu0pWb5mna3D9GG0KCycIMvGKUvi8O9PYIDg1k9ajVtqrchPj2eKZumAFbp9jNmiOXQodCyJTRrljcYP0q7t065z8OvIvS2sin8SNCfTDyJCRMVgypSLaSa+f2IkAi2jN1C/6j+pOekc+fCO80TVpJbD+XfU6Wsyd+Qgl4ikUgkEldhHaGXNfRF4yf189aUCyzHt3d9a/65qHR7hUJ19Hkohnildbi3R4WgCmwYvYGGlRua32tXox1cuAALFog3Xn5ZLBWzQn8S9EWk3KfofbSGvkEDkVWRmgrx8YU/9yNBr9TPNwtvVqgVZHldedY+uJb7m99PjjGHB5Y/wMzdMz0xTImH8WeHe5CCXiKRSCQS1yEj9I7jJ/XzBekX1Y+Xur5EzfI1Gdt6bLHbF3K6R6QVxyaKSHLr6s7vAFAttBqbxmwyZw/0rNsTPv0UDAbo3dtSP9+mjVgePOj0MXiEGzfg+nWx3qiR+W2fj9AHBUG9emLdVh29Pwn660LQ2zM602q0LBy+kKc6PAXAsxue5bU/XsPkTz4QkiIxmUwy5V4ikUgkEkkpsRb0165BerrnxuLt+GGEXuGDAR9w6YVL5nT6orAVoT96/ShGk5HwcuHUCK3hkjHWq1iPQ/85xD+P/0OrwNrwbV5mwSuvWDbytwi9Ep2vWRNCLUZZPl9DD/br6E0mvxL0xxIshnj2UKvUzLxjJu/0eQeAd3e8y4Q1EzAYDW4Zo8SzXEy9SKo+lQB1AE3CmxS/gw8iBb1EIpFIJK5CSblXmrbLtHvb6PVw4oRY9+Ee9M5Acbo/Gn/U3HnBuv98wbRiZxJeLlzUz8+aJSaf2rSBgQMtGyj3Ji5O9DL3dWyk24MfROjBvtN9YiKkpYn1unXdOyYXoEToFUM8e6hUKv7b8798e9e3osvDgdmMWDqCzJxMdwxT4kGUydEmVZqg1Wg9PBrXIAW9RCKRSCSuQonQh4SIpRT0tjl+XKR3V6wItWt7ejQepUGlBgQHBJNpyCTuRhzgfIf7IsnIgJl5dcYvvWTuzQ5AeLiIZoMlo8KXseFwD35QQw+Wayoo6JV/g2rWFKn5PozBaDD3mS8qQm/N4+0eZ9mIZeg0OlaeWMmgBYN8e+JGUiz+nm4PUtBLJBJJ8QQGwtSp4hUY6OnRSJxIoCaQqb2mMrXXVAI1Lri3SoRe+bvx8Tp6lz0K1un2LoxA+wIatYbmEc0BizOz4nDvbEM8m8ydCwkJIh17xIjCnyt19P6Qdm/D4R78LEJfMOVeEfRKjb0Pc/rGaXKMOQQHBFO3ouPZBkObDeW3h34jTBfG9nPb6TWvF1duXinRuS/fvExGTkZJhyzxAIqg91eHe5CCXiKRSIpHq4U33xQvrX+ma92qaDVa3uz9Jm/2ftM1qXhKhF4RqT4u6F32KOzbJ5Z+WD9fGqzr6E0mk6VlnQsM8fJhMMBHH4n1yZMhIKDwNv5UR28n5b5CkHfW0F+5eYWxK8fy+OrHi6//Vq4pLg5ycizv+1H9vJJu3zS8KWpVySRNr3q92D5uO9VDq3P42mG6zunKqcRTxe5nMpl4/8/3qfNpHdr+r63X/Y1ICqOk3MsIvUQikUgkkpKjCHpD3pdvmXJfmD//hK+/Fuvdunl2LF6CtdP9hdQLJGclE6AOcDituNQsWQJnz0LVqvDII7a3UQS9rzvdG43Fptx7k1hbenQpLb5uwQ+HfmD2gdlM3zG96B1q1YLgYPFvz9mzlvf9SNAfu55niFdM/bw9Wldvzc5Hd9KwckPOJp+l25xu7Lu8z+72qfpUhi8ZzqubX8VoMhKbGMvoX0ZjNBlLdX6J6zEYDeaJHynoJRKJ5FbGaISjR8XLKP/j9ieMJiNH449yNP6oa76UKSn3mXnGSz4eoXf6o3DmDAwdKiKI990HI0c64aC+j3WEXjHEaxbeDF2AzjUnPHMGnnoKxo8XPz/zDJQrZ3tbJeU+JgZyc10zHndw6ZJ4LgMCColbbxL0NzJv8NAvDzFy2UiSMpOoV7EeANO2TWPPpT32d1SrbdfR+5Ggt+5BX1qiKkWx89GdtK3RlusZ1+k9vze/n/698LmuH6fjdx1ZcWIFWo2W//b4L0EBQaw7tY5p26aV+vwS1xKXFIc+V0+5wHLUr+T7f/P2kIJeIpFIiiMzE1q0EK9M6YjrT2TmZNLi6xa0+LqFa9yOlQh9Rl6t5enTom2Uj+LURyE1Fe65R9Rrt20L8+cLESIxO93HJcXx14W/ABel2x86BKNHix7ss2ZBVhZ07w5PP21/n4YNReQ3MxP+/df5Y3IXSnS+QYNCpQWKoM/IySAnN6fgnm7j99O/0/LrliyIWYBapea1Hq8R+1Qso1qMIteUy0O/PER6dhGtMG21rpOCvhARIRFsGbuFvvX7kpadxuAFg1lydIn582XHltFxdkdiE2OpHVabHY/s4J2+7/DtXaK141vb3mJN7JoyjUHiGpR0++ZVm5e4LMOX8N8rk0gkEonE01SsaKmfV6mECLp2zbNj8gZyc+HBB+HIEahRA1atsh8RvgWJCImgWkg1TJhYdHQR4ESHe5MJtm2DO+4Q0faFC8X9GDgQNm+G7duhQgX7+2s00DLPXMqX0+7tGOIBhOnCzOuecLrPyMngmfXPMODHAVy6eYlGlRux89GdvN33bbQaLV8N/oraYbU5lXSKyRsn2z9QwdZ1RiOcOyfWfVzQm0wmTiSIVpelTbm3JkwXxroH1zEiegQ5xhxGLRvFzN0zeWnTS4xYOoK07DT61OvDvgn76FirIwBjWo/hqQ5PAfDQiofMjvsS7+FWcLgHKeglEolEInEdGo0Q9SCEK8g6eoCXX4a1a0XbrFWrbvlWdbZQovRnk88CTnC4NxphxQro0gV694YNG0RGxP33C1PC336Dvn0d6zLgD073dgzxAALUAYRqQwH3p92nZafR9fuufLHnCwAmtp/IgScO0Ll2Z/M2lYIrMe/eeQD8b9//+PXkr7YPVjBCf/kyZGeLf5d8/Jm7mHqRtOw0AtQBNKzc0CnH1AXo+Hn4z0zqMAkTJp7d8Cwf/vUhAFO6TmHjmI1EhETk2+eT2z+he2R3UvWpDF08lJv6m04Zi8Q53AoO9yAFvUQikUgkrkVJu4/I+yLo43X0ZWbOHPj4Y7E+bx506ODR4XgrBb+AljpCr9eL33l0NAwbBrt3g04H//mPEHqLFomSh5LgD073dgzxFDxVRz9p3SQOXTtE1XJV2TB6A7PunEWINqTQdv2i+vF85+cBGL96PPHp8YUPVjBCr5jjRUba7mDgQyiGeA0rN3RqhxKNWsMXd3zBtN6iLj4kMIQl9y1hxoAZBKgL/84CNYEsHbGUmuVrcuz6MR5d/SgmHy6r8jdkhF4ikUgkEknZUYzxwsPF8lYW9Nu3CyEJopn9/fd7djxejHVEvlpINaqFVivZAW7eFC3ooqKE2V1srEil/7//E2nXX38t6sdLgz8I+iJS7sEi6FOy3JdyP//gfH449ANqlZplI5dxe8Pbi9x+er/ptIhoQXx6PI+tfqywkFSu7coV8fcg6+cdQqVS8Xqv19n7+F5OPHWCEc1HFLl99dDqLBuxjEB1IMuOLTNH9SWeJTMnk1NJohWhFPQSiUQikUhKjxKhL19eLG9VQX/6tIgQ5+QIN/s33vD0iLwa6wh9iQzxrl2D//5XRGGnTBFp1jVrwocfwvnz8O67UK2EkwMFaZU32XDpkjA19DX0eku02kbKPbg/Qn/s+jEmrpsIwLTe0+hZt2ex+wQFBPHT0J/QarSsObmG2ftn59+gYkVLZtDJk/4l6K+7TtArtK/ZntphjpUmdKnThZl3zATg1c2vsiluk8vGJXGMEwknMJqMVAmuQvXQ6p4ejkuRgl4ikUgkEleiROiDg8XyVqyhT02Fu++GxERo3x7mznW9o/1PP4lUcuse3D5EdNVosyuzQ+n2p0/DxIlQrx5Mnw7JyUKszp4tPnvxRQgLK/YwDlG+vCW674tR+tOnhadA+fJ2Jzcq6IQxoDsEfUZOBvcvu5+MnAz6R/Xnle6vOLxv6+qtebfvuwA8/9vz/JtUoPOAdR29Pwl6JULvBEM8Z/FEuyd4tM2jGE1Gnlr/lKeHc8tjnW6vcsQbxIeRgl4ikUiKIzBQfBl+8UWxLvEbAjWBvNjlRV7s8iKBGhfdWyVCr9Ss+nCEvlSPQm4ujBoFx46JSLG7HO2nT4cDB4SLuw8SHBhMo8qNgGIE/YED4vfbqJFIo8/Kgo4d4ZdfxO98/HhRM+9sfDnt3jrd3s4XfXdG6J9d/yxH4o9QLaQaPw39CY1aU6L9X+jyAr3r9SY9J50xK8bkT723rqP3Q0EfXTXawyOxoFKp+HTQp2hUGk4mnuR8ynlPD8nt5OTmoDfovcJHQGlZ5+/p9gC+7YghkUgk7kCrFemqEr9Dq9Hy4UAX31tF0CtfcC5eFCm/rhBZLqZUj8KUKbB+vchQWLVKiHpXc+kSHBdf+H25tdqMATNYdWIVw5oNK/zhoUPw0kuwcaPlvUGDRAeBXr0cc6svC23aiEkDX/z9FuFwr2CuoXdx27qFMQuZfWA2KlQsGLag5F4JgFqlZv6Q+TT/qjl/X/ybTac3MbDBQPGhH0bor6dfJyFDlHo0qWL/HnqCMF0Y7Wu2Z/el3Ww5s4WxbcZ6ekguJSEjgT/P/8mOczvYcX4H+6/sJ9eUC4j/X3UaHboAXaFlUECQ7c9svBeiDWFUi1FEVogs0dhuFUM8kIJeIpFIJBLXoqTcZ2ZCSAikpwtTMjtmXH7Fd9/Bp5+K9fnzRbq9O/j9d8u6LwrOPO5pcg/3NLnH9ocTJsCePZbWcy+9ZGkn5w58OUJfjMM9uCdCfyrxFE/8+gQAr/d8nX5R/Up9rMgKkTzS5hG+2PMFn+/+3CLolUmLI0fEZCLkE/Qmk4mPd31MliGLyV0mExwYXOoxuAslOl+3Ql2bHQA8TZ96fYSgP+t/gv58ynmzeN9xfoe524AtsnOzyc7N5mZ22Vv5bTq9iU1jSuZLcKu0rAMp6CUSiaR4jEZhJgXCaMrVtb8St2E0Gc1pkZEVIs01y05FidAnJgrH8ZgYESnzQUFfokdh61ZR0w3w1lswominaKdiLehPnRIO34opoT9gNIq/I4C//oJOndw/BkXQHz8ueptrndc6zOUU43APrq+hzzJkMXLZSNKy0+hVtxdv9Cq7SeTTHZ/myz1fsu7UOk4mnqRxlcYWQa/8vQQF5fMN2HR6E1M2TQFgQcwCfhr6E+1qtivzWFyJ2RDPi+rnrelTvw/v73yfLWe3YDKZfLZ+22QycSLhhFm8bz+33WYZQbPwZvSI7EHPuj3pFtmNikEV0Rv06HP1ZV6mZ6fz7f5v+ePMH1xPv07VkKoOjT05K5kLqRcAaB7R3Km/F29ECnqJRCIpjsxMS0QjLU1EWSV+QWZOJvU/F/c27dU010R7rAV9/frii7WP1tE7/CjExcHw4WAwiPru11932xgxmSyCXqUSPx8+DN26uW8Mrub8eXEztFpo5yHxFRkpXNSTk0WtvjuzA8pKCVLuXSXoX9z4IgevHiS8XDgLhy8scd28LRpVacTgRoNZe2otX+z+gi8GfyEmETUa4WUBwjQxT2CaTCbe3PomINL2TyScoPP3nZnaayqvdH/FZt91b8CVLeucQdc6XQlQB3A+5Txnk89Sv5JvlThcS7vGCxtfYGPcRnNpg4JGpaFtjbb0iOxBj7o96B7ZnfBy4S4dz97Lezlw9QCrYlfxWNvHHNrnaPxRAGqH1TY/y/6MDDNJJBKJROJKlJT7pCSLM/iWLZ4bj6tJSYG77hLX26EDzJnj+npua44dg6tXRc1+v7wUZh9Ou7eJ4g/QqJHFbNHdqFS+mXafnAzx8WK9USO7m7lS0C87toxZe2cB8OPQH6lZ3nm+Es92ehaAeYfmkZKVIiZ9rGvmrdY3nd7Erou7CAoI4vB/DjO82XAMRgOvb3mdHnN7FHbM9xK80RDPmlBtKB1rdQRgy1nf+rc+LimObnO6sTBmIQkZCQQFBNG7Xm9e7/k6Gx/aSPIryex5fA8f3/4xQ5oOcbmYBxjebDgAy48vd3ifXRd3AbdGuj1IQS+RSCQSiWuxjtCPGSOE0NKlIiXd3zAYRD33iRNQq5YwwQt2c02uEp3v0QM6dxbr/iboT5wQy2YejlD6oqBXovM1ahRZhuEqU7zTN04zfvV4AF7p9gqDGg5y6vH7R/Unumo0adlpzDkwR7xpXVqQJ+ito/NPtn+S5hHNWTpiKT8M+YEwXRh/X/yb1t+05n///M8rHMutUeq2vTVCD6KOHnxL0B+4coBuc7oRdyOOqEpRbB27lZRXUtgydgvT+kxjQIMBhGpD3T6u4dFC0G8+vdmhCTaTycQPh34A4O7Gd7t0bN6CFPQSiUQikbgSa1O8pk3hySfFz5MmQU6O58blCiZPht9+EyJ+9WohmtyNIugHDLCkgR844P5xuBIlQu8tgt6XJkwcSLcHqBDk/Br67NxsRi0bRao+la51ujKtzzSnHVtBpVLxTMdnAPhizxfkGnPzX2ueoLeOzr/U7SXzvmNajyHmyRh61+tNRk4G/1n7H+76+S6upl11+lhLw039TS6mCnM/b62hBytBf2aL102I2GLLmS30mteLa+nXaFO9DTsf3Umver3QajzvjdE0vCnRVaPJMeawJnZNsdsfuHqAmPgYdBodo1qMcsMIPY8U9BKJRCKRuJKwMEtadFISvPMOVK0qUsM//9yzY3Mm//sfzJwp1n/8Edq2df8YcnIsmQ/9+1sE/ZEj/jV5ogj6pk09Ow7l93vokKUto7fjgMM9uCbl/pXfX2Hv5b1UDq7MouGLCNQEOu3Y1oxpPYZKQZU4k3yGX0/+WihCbzKZmLp1KiCi89VDq+fbP7JCJJsf3swnAz9Bp9Gx7tQ6WnzVgl+O/+KS8ZaEEwkiOyUiJILKwZU9PBr7dK3TFa1Gy6Wbl7y2dEFh2bFlDFowiJvZN+ldrzdbx24t9DfhaUqSdj/3wFwAhjQdQqXgSi4dl7cgBb1EIpFIJK5EpbJE6RMToVIlmDFD/Pzmm5ZWUt5EXBy89hpcuODY9n/8AU89JdbfeUcY4nmC3buFW194OLRqJaKRYWGg11uczf0Bb0m5j44WhmtJSXDpkmfH4igOONyDRdCn6lNFlLuMrI5dzad/ixaO8+6dR50Kdcp8THuUCyzH420fB+Dz3Z8XitBvjNvI3xf/zhedL4hapeb5Ls/zz4R/aF2tNYmZiQxfMpxxK8eJ2nwP4e318wrBgcF0ri1Kfrw57f6bf75h5NKRZOdmM6zZMNaPXm/OTvEmFEH/W9xvpGWn2d1Ob9Cz8MhCAB5p84hbxuYNSEEvkUgkEomrsTbGA3j4YejaVfSknzzZc+Oyx4svwrvvClO73buL3vbUKbjvPlE//+CD8H//554x2kJJt+/XT/TUU6t9My28KBISxAuKTRt3OUFBliwBX/n9Oppyr7OImrL20T6fcp5xK8cB8ELnF7i7ievreid1nIRGpWHL2S0cq2yZkDDVq8eb294EbEfnC9IiogV7Ht/Dq91fRa1SM//QfFp904ptZ7e5cvh2Mbes8+L6eQVvrqNPzEjk9T9e58m1T2LCxBPtnmDJfUsICgjy9NBs0qpaKxpUakCWIYt1p9bZ3W7NyTUkZSZRq3wt+kf1d+MIPYvPCPqkpCRGjx5NWFgYFStWZPz48aSl2Z+hSUpK4umnn6ZJkyYEBwcTGRnJM888Q0qK52YVJRKJjxIQIPppT5zoOUdpiUsIUAcwsf1EJraf6NoWTdbGeCCE5qxZYrlkSf6+6Z4mNRXWrxfr165B796weDFg41FIToa774YbN0Qv9Nmz3etoXxDl99jf6oucv9XRK+n2detCuXKeHQvkT7v3dkwmh1PudQE6ggOEoWNZ0u5zcnN4YPkD3Mi6QYeaHXiv/3ulPlZJiKwQydBmQwH45NwiePVVeOMNNibt5e+LfxMcEGw3Ol8QrUbL9H7T2T5uO1GVojifcp4+8/swZeMUsgxZrryMQhxL8H5DPIWS1tGnZadx+eZlEjMSSctOIyc3x2n19zf1N1l3ah0vbnyRtv9rS9UPq/LOjncAeKPnG3x959dOaZ3oKlQqlUNp9/MOzgPg4dYPe/X1OBuf+WY6evRorly5wqZNm8jJyeGRRx5hwoQJLFy40Ob2ly9f5vLly3z00UdER0dz7tw5/vOf/3D58mWWLVvm5tFLJBKfRqcT4kvid+gCdMy60w33LgiCNgAAIABJREFU1jrlXqFNG5GmPnOmWB46JP7WPM2aNSJFvWFDkdK9Zo3oJR8bi+7115k1K0+wGwwwcqRIYa5TB1audL+jvTWpqfD332J9wADL+4rg9JUIcnF4iyGeQuvWsGCBbwj6S5cgI0PMRtUvvjd4haAKZKZllknQv77ldf668BcVdBVYfN9it5qMPdfpOZYdW8aCmAW8/9oFqgRX4c05XQHHovMF6RbZjYNPHOSF315g9oHZfLTrI36L+42fhv1Eq2qtXHEJhTBH6L3YEE+hU+1OBAUEcS39GrGJsTQNt+95cfz6cTp814H0nPR876tQoQvQodPo0Gq05vVil3nrGpWGfVf2sefSHnJN+UtHoqtG82KXF3nkNt9ITR8ePZwZf81g7cm1ZOZkEhyY//+bKzevsP5fMRk9rs04D4zQc/iEoD9+/DgbNmxg7969tG/fHoAvvviCwYMH89FHH1GzZuH+nS1atGD5cssMToMGDXj33Xd56KGHMBgMBNiJsun1evR6vfnn1NRUJ1+NRCKRSG45lAi9knKvMG2aiH7HxsKnn8Irr7h/bAVZskQsR40SNf4vvwwffwxTp4ra7TlzRKr188/Dpk0iSrx6NVT3sInS9u2QmysmIurWtbx/221iefCgiNB6MoPAGXhL/byCL7WuU6LzUVEQWLwhXcWgilxNu1pqQb/h3w18sPMDAL6/53vqVyp+EsGZdK3TlXY12rHvyj6+3fct7Wq0M0fnp3SbUqpjlteV57t7vuPuJnfz+JrHiYmPof237Xmn7ztM7jLZpVFRvUFP3I04wDci9EEBQXSp3YUtZ7ew5cyWIgX9tO3TCol5ABMmsgxZTsmEaFCpAX3r96Vv/b70rtfb64zviqNDzQ7UCavDhdQLbIzbyL1N7833+U+Hf8JoMtK1TlcaVyk6A8ff8AlBv2vXLipWrGgW8wD9+/dHrVaze/duhg4d6tBxUlJSCAsLsyvmAd577z3eeuutMo9ZIpH4ESaTpWY1PNz3BYHEjMlkIiFD3NvwcuGoXHVvC6bcK1SoAB99JPrTv/22qEGPjHTNGBwhNRU2bBDrI0cKw7OPPjK32zP9/DMJJ2/AwIGEf/klKoCffrJEwT3Jpk1i2b9A3WR0tIjIJiUJkz9P/n6dgbc43Csogv7UKeEJERLi2fEUhYPp9grmXvSlMIG7lHqJMSvGADCpwyRzL213olKpeLbTszy88mFm7Z1F7bDaQOmi8wW5p8k9dK7dmQlrJrAqdhUv//4yv578lflD5rts4uJU0imMJiNhujBqli8czPNG+tTrIwT92S082eFJm9vEJsSy+IgoazrwxAFaRrREn6tHb9CXepmdm40+VywbVW5E3/p9qVuxrs3z+woqlYphzYbx+e7PWX58eT5BbzKZmHtQuNuPaz3OQyP0HD4h6K9evUpERES+9wICAqhcuTJXrzrWFzMhIYG3336bCRMmFLndq6++ygsvvGD+OTU1lTp1XOdEKpFIfICMDFD+DUpL8+4vrJISkZGTQcRH4t6mvZpGiNZF97agKZ41o0fDd9+JCPPzz8Py4tvyuIzVqyE7W4jFFi0s7z/2GDRoQMawMUTsWw/7II3XCJn+Gjg4qe5ybNXPgyhjiI6Gw4dFlN5fBL23ROirVYMaNeDKFdixAwYN8vSI7KM43DtoJlja1nUGo4EHf3mQhIwEbqt+Gx8N/KhE+zuTkc1HMmXTFC7fvMzlm5dLVDtfHBEhEay4fwVzD87l2Q3PsuP8Dlp904qZg2Yyrs04p0+QWhviuWzy1cn0qd8HtsLWs1sxmUw2xz39z+mYMHF347tpU11MjpZTl6NcoBd4ZHgZw5sN5/Pdn7M6djXZudnmEpa9l/dyPOE4wQHBjGw+0sOjdD8eNcV75ZVXUKlURb5OKKllZSA1NZU777yT6Oho3nzzzSK31el0hIWF5XtJJBKJRFIm7EXoQWR8zJolouG//GKJkHuCpUvFcsSIwpkoffrAFiu35lEPeEeJAMDly3DsmBhznz6FP/eXOvqMDDh3Tqx7i6AHS5tCb/caKWGEXnG6L6mgn7ZtGtvPbSdUG8ri+xZ71DlcF6DjyfaWyPDEDhOpFlrNacdXqVQ8etujHP7PYbpHdictO41HVz/K0MVDiU+Pd9p5AI5dzzPE84H6eYWOtTpSLrAc1zOuc/T60UKfxyXFseDwAgBe7/m6u4fnc3St05VqIdVI0afwx5k/zO8rveeHNRvmlW33XI1HBf3kyZM5fvx4ka+oqCiqV69OfHz+fxQMBgNJSUlUL6Zm7+bNmwwaNIjy5cuzYsUKAh2omZJIJBKJxKnYMsWzpkULePZZsf7005DlXudoAFJS8qfb26JRI8v6N994T/nJ5s1i2a6d5XdtjXUdvS+jRJirVBHlP97C00+L5dq18O+/nhuHyQQTJoisAVuv334T25Uw5b4kgn7z6c28s124h39393c0qtKomD1cz3/a/4dQbSjlteWZ0rV0tfPFUb9SfbaO3coH/T8gUB3IqthVDPxxoNNc2sHSg94X6ucVtBot3ep0A4TbfUHe+/M9ck25DGo4iA61Orh7eD6HRq1haFORFbb8mMhmyzJk8fORn4Fbq/e8NR4V9FWrVqVp06ZFvrRaLV26dCE5OZl9+/aZ9/3jjz8wGo106tTJ7vFTU1MZOHAgWq2W1atXExTknb0VJRKJROLn2DPFs2bqVJG6/O+/om69JCgeD2VhzRpLun3z5sVv700tHJV0e2t3e2v8pXWdt6XbKzRuDHfcIQT1F194bhzr1onylfh426/cXKhY0WHPh5IK+qtpVxn9y2hMmHi87eOMajGq1JfiTKqFVmP/hP0ceOKAU6PzBdGoNbzU7SX2Pr4XjUrDoWuHuHTzktOO74uCHuz3oz+XfI75h+YDMjpfEhQ/ipWxKzEYDaw8sZIUfQqRFSJFicMtiE/0oW/WrBmDBg3i8ccfZ8+ePezcuZOnnnqKUaNGmR3uL126RNOmTdmzZw9gEfPp6el8//33pKamcvXqVa5evUpubm5Rp5NIJBKJxLkUlXKvEBYGn3wi1t99F86cKf64JhNMmgRVq8L335dtjIq7/ciR3hN5dwSTyX79vIJi3Hb2LCSXvgWZx/FWQQ+WDJO5c4W5orvJyQHFA2nSJIiJsf06e1aIegcwm+LpizfFyzXm8tAvD3Et/RotIlrw+aDPS3slLqFRlUY0qNzALedqXb21OS3+4FXnZMXkGnOJTRAZKtFVo51yTHehiMxt57ZhNBnN73+w8wMMRgN96/ela52unhqez9Grbi8qB1cmISOBHed2mHvPj209FrXKJ6St0/GZq16wYAFNmzalX79+DB48mO7du/Ptt9+aP8/JySE2NpaMjAwA9u/fz+7du4mJiaFhw4bUqFHD/Lpw4YKnLkMikUgktyLWKfdFpaDef7+oAc/KgueeK/qYJpNoKffVV+Lnd98VEcjSkJJiSUe2l27vrRw/Lmrog4Kgq50vxZUqWVrZ+UJ7NXt4W8s6awYOFNkdN2/CvHnuP/9XX4ka+YgImD5dlLHYelVwvL62JDX07/35HpvPbKZcYDmW3LekUI/sWw3F3O3QVec8b3E34tDn6tFpdNSrWM8px3QX7Wq0I1QbSlJmEjHXYgDRBeH7A2IS9o2eb3hyeD5HoCaQe5sIh/uZe2ay6bTocDK29VhPDsuj+Iygr1y5MgsXLuTmzZukpKQwZ84cQkNDzZ/Xq1cPk8lE7969Aejduzcmk8nmq169ep65CIlEIpHcmigReoNBdEqwh2KQFxAgHOd//dX+tu+9Bx9+KNaDg0VEf82a0o1Pcbdv1syxdHtvQonO9+ghRL09/KGO3tta1lmjUsEzz4j1L74Ao7Ho7Z1JYiIoLYfffltkuzgBR1Put5/bztStUwH4+s6vfcq0zVW0riayYg5ec87ztuPcDgA61Org0l73riBQE0iPyB6AJe1+xs4ZZOdm0yOyB73q9fLk8HyS4c3y0u5PrMRoMtKzbk+3ZaB4Iz4j6CUSicRjBATA2LHi5U11w5IyE6AOYGzrsYxtPZYAtQvvbXCwaJ8GRafdgxDVSurwM89AZmbhbWbNgv/+V6x//LElmv/ZZ6Ubn3W6fRF45aNQXLq9gq/X0RsMFpd2b4zQA4wZIyLg//4L69e777xvvQU3bkCrVjB+vNMO64igv55+nQeWP4DRZGRs67E83Pphp53fl3F2hH77+e0A9Izs6ZTjuZve9XoDQtBfTbvKt/tFlrGsnS8d/aP6E6azTNzdir3nrZGCXiKRSIpDpxMppPPmWUSZxC/QBeiYN2Qe84bMQxfgwnurUjlmjKfw+utQu7aIun/wQf7PfvwRnnrKst0LL8DEiUJhb9tW8gh0cjJs3CjWR4woclOPPAoxMWJiY+5ckVpvTU4ObN0q1u0Z4in4euu6M2fE9QYHQ2Skp0djm9BQeOwxsf65m2rIjx+3lJ18+qlo/+gkHKmhH796PJdvXqZpeFNmDfbytn1uRInQ/5v0L2nZRWQlOcj2c3mCvq5vCnrFGG/b2W3M2DmDLEMWnWp1on9UMROREpvoAnTc1fguAEICQxjRvOj/u/wdKeglEolEInEHjhjjKYSGCnEC8P77EBcn1leuhEfy2vI884wlzbh2bYsYL6mQUtLto6O9M91+6lSRwv3oo1CrljC4e/ll2LIFdu4UNdtVqliM7+yhpNwfOyau19dQ0u2bNAG1F399e+opMb5Nm8Tv2tW8+KLwjrjnHujb16mHVvpZ24vQxybEsubkGjQqDUvuW0KINsSp5/dlqoZUpWb5mpgwmevGS8v5lPOcTT6LRqXxWfO422rcRpgujBR9Cp/vFv9Gv9HrDVS+ZEDqZUxoOwG1Sm1uy3gr48X/I0gkEomXYDJBerp4ObGnrsTzmEwm0rPTSc9Od2q/ZJsU14u+IMOHi6izXi/6fG/aJEzzcnNh3Dgh+K2/DCpp9wsXwrVrjo9r6VKxdMAMzyOPwqlTYhkVJa738GGYMUOItz55LYr69Ste5NapI8zxcnLcIzSdjTc73FtTrx7cKwyrmDnTtefasEG0qgsMLHmrRwewTrm39e/DwpiFANze8HZaVmvp9PP7OuY6+jI63Sv1821rtKW8rnyZx+UJAtQB5uwCo8lIuxrtuKPhHR4elW/Tq14vkl5KYsaAGZ4eiseRgl4ikUiKIyNDRExDQ8W6xG/IyMkg9L1QQt8LJSPHxfe2JCn3IMTrl18KsbJ+Pdx9t4gsDx8uem0XFLAdO0KXLmKbb75x7BzJyRZ3+2LS7cEDj4LJJNqMgRBu8fFiwuLhh4WbucLddxd/LJXKt+vovdnhviBKC7sffhC17a7AYIDJk8X6009Do0ZOP4Ui6I0mY6G0cZPJxIKYBQCMbjna6ef2B5Q6+rIKel9Pt1dQ0u4BXuv5mozOO4EKQRVu2VZ11sjfgEQikUgk7qCkEXqAxo2FeAURqe/XDxYssO9Ipwipr74S2xfHqlUiYt28uUi59zYSEy1dASIjITwcHngA5s+HK1dg/37RCWC0g4LKl+vovdnhviA9ewqDusxMmD3bNef49luRaVGlivCScAHBAcEEqgOBwnX0ey7tIe5GHOUCy5lbaEnyo0ToD10rmzGe2RDPxwX93Y3vRqvR0rl2Z+5pco+nhyPxI6Sgl0gkEonEHZQ0Qg/C1Xz1asvPbdsW7UY3bJiop4+Ph0WLij9+CdLtPYISna9eXZjBWaNWi7r4O+/MX3pQFL7aus5k8p2UexD3Q5lc+vJLEU13JjduwBt5vbunTYOKFZ17/DxUKpVdp3slOj+k6RBZO28HJUJ/+Nphco25pTrGtbRrnEgQ2SndI7s7bWyeoFGVRsQ9E8emMZtkVFniVORfk0QikUgk7qAkpngA58+LVmzXr0P9+uK9zz+3tC6zRWCgxQH/s8+KLnQvgbu9x1AEvXL9ZcU6Qu/OPull5coVSE0VkxguSC13CQ8+KDIqzp/PPynlDN5+WzxH0dEwYYJzj10AW8Z4BqOBxUcXAzLdvigaVm5IucByZBoy+Tfp31IdY8d5UT/fMqIllYMrO3N4HqF2WO1b3sBN4nykoJdIJBKJxB2UJOX+2jVhiHfhgnA137UL7rhD1Mc//XTRQv3xx0U0++BB2L7d/nbz5ol0+xYtvDfqe+aMWNar55zjNW0KWq0Qx8pkgS+g1M9HRflO68ygIHjiCbHuzBZ2J0+KrgcAn3xiv/zESdiK0G8+vZn49HjCy4UzIKqYdom3MBq1hpYRwiywtHX0Sv18r7q9nDYuicTfkIJeIpFIJBJ34GjKfXIy3H67EC6RkcLdvlo1IWJ0OhFVX77c/v6VK8PYsWL9s88Kf56QAA89BM8/L352tP7cEyii21mCPjBQTGCAb6Xd+1K6vTVPPikE9/btcPSoc445ZYpI4R88WDwnLsbciz7LUkOvpNvf3/x+AjWBLh+DL1NWYzx/McSTSFyJFPQSiUQikbgDRyL06emiJvzQISHif/9dtFsDaNBA9F8HIcbT0uwf55lnxHLVKjh9WqybTKKuvlkzYaynVsMLL4iXt+LslHvwzTp6XxX0tWpZRPeqVWU/3ubNIn1fo4GPPy778RygYIQ+IyeDFSdWADLd3hHKYox3I/MGh68dBqBH3R5OHZdE4k9IQS+RSCTFodHAffeJl0bj6dFInIhGreG+6Pu4L/o+NGoX39viIvR6PQwdCn/9JUy+Nm4sXC/9yitC3F68KOqI7dGsmRBSJpMwJbt0CYYMEQ7xCQnC1f6vv4Qo0modvgS3PwrOTrkH72tdl50tSiyKwpda1hVEaSm4Zk3ZjpOba8kqmTjRbW7/FXT5a+jXxK4hLTuN+hXr07l2Z7eMwZcpS4R+54WdmDDRuEpjqodWd/bQJBK/QQp6iUQiKY6gIOEGvnSpWJf4DUEBQSwdsZSlI5YSFODie6sI+hs3ChuyGQxCbG/aBCEhou98q1aFjxEcDDNnivVPPrFEbm3x3HNi+e23wjxs9WqRcv7WW6LdW6dOJb4Etz4K1j3oXSHovSVC/8gjojPBpk32t/GllnUFuesusdy9W3RfKC3ffw8xMVCpEkyd6pyxOUDBCL2Sbv9gywdlH3EHaFmtJSpUXEm7Qnx6ye6/Od0+UqbbSyRFIQW9RCKRSCTuQEm5NxpFnbyC0QiPPQYrVoho+apV0LmIyN9dd4mop8EgHO3tGeQNHCgEYHq6MIHr1ElEpd94o0RReY9x/broY65SCS8BZ6FMlFy8KLIVPElGhvBDMBhE1FmvL7xNyv+3d+fRUVXp3sd/VSGBJJAwJgGEAK2gDCKNjKKAzAYE27ZtccLhOtEKzkOr4LVVBOfpSqsM2iKCetUriA2NgCKTGAQiIvYrihIQaZJAQub9/rGtSgJJqhJTw6l8P2vVqkPVyT771MMmPLWnbGnvXnvsxB76tm3tdovGSEuW1K6M7Gzp3nvt8fTpZV+OBUH5hP5g3kF9+O2Hkhhu76/GMY11YvMTJUlf7qvZsPvV36+WxPx5wBcSegAAgiEmRmr863ZFnmH3xtie9Pnz7Rj2RYukYcN8l/X007aLfOVK6c03Kz/H7bbn9expe/PXrrVD7Z3CM9y+TZu6Xdk9IUE60SYYmjTJLhy4bp398iDYVq8uS+K//bbyeeGe4fatW0uJicGrW136rcPuH37YfsHTpYtdaC+IvIviFWRr8VeLVVxarF4pvXRKKwd+uRIiPVNqPo/+SOERbd67WZI0uAMr3APVIaEHAF9yc20voctljxExcgtz5XrAJdcDLuUWBiG2xy6Md//9dvV6l8sm9ePH+1dOx47SPffY41tukQ4frvy8kSPt0PKbb66TSe9BbQqBGG7v4fnSZMkS+9kMHGgT/d69bcI4d65dlb2kpO6vXd6yZfbZs+jf3/4mff99xXM8Cb0Th9t7eBL6f/5Tys+v2c/++99luzU8/ridNhJE5efQL9i2QJIdbg//nZZc83n06/asU4kpUWpiqton1uEIHSACkdADABAsnqHCBw9Kjz1mEzjJLlxX0+3jbr/d9jRnZtphyJEmECvcezz3nE0u//Y3m2wmJ9th7198Ib34onTllXZ7u6ZNpaFD7e4Cb78t7dlT9RSH2vAk9I89Jg0ebEcJHLvrgFNXuC/v97+3Iy1yc6VVq2r2s3fcYRcOHDnSblUXZJ4e+owDGfrkh0/kkksXdb8o6PVwstosjMd2dYD/GoS6AgAA1BuehP7pp21CKUmPPGLnT9dUo0a2d3/MGFveFVeU7bEeCQKxwr1HgwbSiBH2Idkkfc8eaePGssfnn9utAVetqpiEpqTY9Qj69rWP00+3iX9N/b//J33zja3LsGFS5852wb533pE++qhsu7dISOhdLvvFyezZdtj96NH+/dzq1fbzcLtt73wIFqHzJPR7D9t1DIZ0GKK2CW2DXg8n8wy5//qXr5VfnO/XAqRrfiChB/xFDz0AAMHiGXLvSebvvNNuRVdbo0fbre5KSqT//u/fXr9wEsgh98fyLLz3xz9KM2faBD47266q/sor0rXX2mQ7Kkrat88uXPjXv9ovBJo1s8PhL7vMnnvsDgZV8fTODxxo58Z37y7ddJN97cYby+bWR8KQe6niPHp/RjmU36bu2mtD9mWVJ6H3YDG8mmvbpK1axLZQiSlRxs8ZPs/PL87Xhh83SCKhB/xBQg8AQLCUX537uuts7/xv9cAD9vntt8uS4EgQyCH3/oiKsknklVfaYfjp6Xa3gE8/tYsM/vnPUqdO9tydO6XXXrO7Fbz+un/lexL68r3V06fbEQC7dtlrFBbaOeSSs3voJenss+22i3v2SFu3+j5//nz7mScmlv0dD4HyCX1MVIzO73p+yOriVC6Xq0YL4236aZMKSgqU0jhFJzU/KdDVAxyPhB4AgGDx7IF+ySXS88/XzRDiHj2k4cNtz/Czz/728sJBaWlwe+j9FRcnnXGG7Tl+4w2bbB84IC1dKl1wgT3npZd8l1NQYHcokCom9AkJdj69ZOf3r1xpe6qbNLFz0J0sNrZsioOv1e4PH7YjICTpvvukVq0CW7dqJDYq21kg7aS043rs4Z+aLIxXfrs6VwimWQBOQ0IPAECw/Nd/2e3JXn3VzguuK56F1F56yfYiO93+/Tbpdbuldu1CXZvqtWxp1zF48klb308+sT321Vm71i4Ql5JS9iWPx8SJ0lln2T3qJ02yr518ckjmj9c5f7evmzHDTm048UQ7/SCEGsc0lttl2yrD7WvP00PvT0LvXRCvPcPtAX+Q0AOAL1FRdnXlc86pk62/ED6i3FE656RzdM5J5yjKHYTYulzS735X98nZqFE26Tt82M7jDpCgNQVP7/wJJwR9m7Jaa9vWJvaSNGdO9ed++KF9HjXq+L8LLpddhT8qyn6xITl/uL1HWpp93rjRJuyV2b3bLoAn2dEKMTFBqVpV3C63JveZrHNOOkdjO48NaV2czLPS/Zf7v5SpZg2FopIifbbnM0nMnwf8RUIPAL40amT3q16yxB4jYjRq0EhLJi7RkolL/Fp5OWy53WULiD39tN2CLQCC1hQCucJ9IF19tX2eP18qKqr6vMrmz5fXo0fFnulISehbt5b69LHHS5ZUfs5dd9nRGUOHSueeG7y6VeOZMc9oycQlatigYair4lgntzxZ0e5o5RTkaHfW7irPS9+XrtyiXDVr1EzdkroFr4KAg5HQAwAQCS691C669/330rvvhro2v02oF8SrrbQ0u6f9/v1VJ6w//iht326/hPHMKa/M9Om2LEnq2bPOqxoynmH3779//Htr10pvvmlHKTz5ZGRMM4Aku6CgJ0GvbmE8z3D7M1PP9E51AFA9WgoAAJEgNrZsP/snnghtXX6rcFwQzx/R0Xb7OqnqqQ8ffWSf+/atuOvBsRITpRUrpBde8H/fdifwJPTLl0tHj5a9XloqTZ1qj6++OrK+xIAkqWey73n0noR+cOrgoNQJiAQk9ADgS26uFB9vH7m5oa4N6lBuYa7iH45X/MPxyi2MgNjecIOdc7xunbR+fZ0XH7Sm4NQh95J01VX2eelS6aefjn/fM3/enyS9e3fp+usjq6e6Z0+70OHRo2Ur/Ut2u7/PP7cr+j/4YOjqh4ApP4++MkUlRfrkh08kMX8eqAkSegDwR16efSDi5BXlKa8oQmKbkmJXSZfskOUACEpTcOqQe0nq0kUaNMj2OM+fX/G9oiLbMy1FVq97Tbhc0thfF5fzrHafm2vnzkt2uzrPVANEFE9CX1kPfU5Bjsa9MU5Z+Vlq1qiZ91wAvpHQAwAQSTyL4731Vlli7CSlpXYdAMmZPfRSWS/9nDn2fjw2bLDbCjZvLp1+emjqFg48w+4/+EAyRpo5U9q7136BM2VKaOuGgPEMud+dtVtZ+Vne13/M+VFnzj1TH/37I8VFx+m1815TA3eDUFUTcBwSegAAIsmpp0rDhtlE8tlnQ12bmtu71/ZkR0XZreCc6IIL7NDxf/9bWr267HXP6vYjR9bvLTCHDrXzNn76yfbSz5plX585k51EIliz2GZqn9hekrR1/1ZJtre+38v9tHX/ViXHJ2v1pNVK65wWymoCjkNCDwBApLnlFvv80ku2R9hJPKMK2reXGji0ly4+XrroIntcfnE8T0Lv2a++vmrUqGyF/4svtvPpzzxTOv/80NYLAVd+Ybxl3y7TmXPP1N7De9W1VVetv3q9Tm9Tj0euALVEQg8AQKQZPVo6+WTp8GE77NtJnLrC/bE8w+7ffls6dMhuZbd5s31t5MjQ1StceIbdHznCNnX1iGdu/PObntfYBWN1pPCIzu54ttZeuVYdmnYIbeUAhyKhBwAg0rjdZVuAPf20VFwc2vrUhJNXuC+vTx+7Sn1+vrRggfTPf9rXe/WyixfWd2lpZQn85ZdLvXuHtj4ICk/TMb0MAAAcmklEQVQP/TcHv1GJKdHlPS/Xhxd/qKaNmoa4ZoBzkdADgC9utzR4sH24+Wczkrhdbg1OHazBqYPldkVYbC+91O5zvnu39I9/1EmRQWkKTl7hvjyXy+6nLtlh957h9vV1dftjJSdLkybZXQEefjjUtUGQlB9S/8CQBzR3/FzFRMWEsEaA87mMMSbUlQhnOTk5SkxMVHZ2thISEkJdHQAA/Pe3v0n33Sc1bCitWGG3Uwt3w4bZ/clffdV+KeFkBw9KbdpIhYV23nh+vrRmjZ0vDtRTizIWKbFhokadOCrUVQHCmr95aIR1RwAAAK+77rJzlQsKpHPPlXbsCHWNfIuUIfeSHSExYYI9zs+XEhKk/v1DWycgxP7U7U8k80AdIqEHACBSNWggLVwo9etnF2YbM0bKzAx1rapWXCzt2WOPnT7k3sMz7F6Shg+XoqNDVxcAQMQhoQcAX3JzpVat7CM3N9S1QR3KLcxVq1mt1GpWK+UWRmhs4+KkDz6QTjpJ+v576Zxzar2VXcCbwt69NqmPjpZatw7ABUJg2DApNdUeM38eAFDHSOgBwB+//GIfiDi/5P2iX/IiPLYtW9pF2ZKSpC1b7H7fhYVVn19QYJP/SpbZCWhT8Ay3b99eiooK0EWCzO2W3nhDuvdeu5o7AAB1iIQeAID6oFMnaelSKT7eLpB39dUVE/b//Ed67TXpj3+0XwB06CAtWhTcOkbKCvfHGjBAevBBKYbVvAEAdatBqCsAAACCpHdvafFiu1Dea6/ZRdtSU6X33pM++UQqKal4/nvvSRdeGLz6eRL6SFgQDwCAICChBwCgPhkzRnrpJenKK6Wnnqr4Xo8e0vjxtod+6lRp/frg1s0z5D7SeugBAAgQEnoAAOqbK66QDhyQpk2z26iNH2+3tevUyb6fnS3dfLNNsPfvl5KTg1MveugBAKgR5tADAFAf3XGHdPSo9PHHtjfek8xLUmKi1LWrPd6wIXh1IqEHAKBG6KEHAF/cbun008uOETHcLrdOb3O69xjl9O8vZWTYYffnnispwE2hqCjy9qAHACDASOgBwJfYWGnTplDXAgEQGx2rTf9FbCvVv7/0yisV5tEHtCn8+KNUWio1bBi8If4AADgc3REAAOB4/fvb540bj1/9PhA8w+1TUxkJAwCAn/iNCQAAjnfKKVKTJlJurh16H2iscA8AQI2R0AOAL3l5dpGuDh3sMSJGXlGeOjzVQR2e6qC8ImJbQVSU1LevPf512H1AmwIL4gEAUGMk9ADgizHS99/bhzGhrg3qkDFG32d/r++zv5chtsfzDLv/NaEPaFMgoQcAoMZI6AEAQOUGDLDP69YF/loMuQcAoMZI6AEAQOX69bPPX38tHToU2GvRQw8AQI2R0AMAgMq1bCmdeKI93rgxcNcpLJR++skek9ADAOA3EnoAAFC1Y+bRB8QPP9hJ+bGxUlJS4K4DAECEIaEHAABVC0ZCX364vcsVuOsAABBhGoS6AgAQ9lwuqWvXsmNEDJfLpa6tunqPUQlPQr9hg1ymVF272r6AOv24PAviMdweAIAaIaEHAF/i4qSMjFDXAgEQFx2njBuIbbVOPVVq1Eg6dEhxP+1SRkaXur+Gp4eeFe4BAKgRhtwDAICqRUdLp59ujwMx7P7dd6WXX7bHnTrVffkAAEQwEnoAAFC9QMyjP3hQuvhi6bzzpJ9/lk45Rbr88rorHwCAeoCEHgB8ycuTunWzj7y8UNcGdSivKE/dXuimbi90U14Rsa3Srwl93mdb6qYpvP++1L27tGCB5HZLd94pffGF3SYPAAD4jTn0AOCLMdJXX5UdI2IYY/TVga+8x6jCrwm92bZdX/36MdXq4zp0SJoyRXrtNfvnk0+W5s2T+vWrk2oCAFDf0EMPAACq17at1K6dZEprX8YHH9iu/ddes73yt98upaeTzAMA8BuQ0AMAAN888+hrKitLmjRJGjdOysyUOneWPv1UmjnTrp4PAABqjYQeAAD4VpuE/sMP7Vz5+fPtxvW33ipt2SINGFD39QMAoB5iDj0AAPCtJgl9drZ0yy3SnDn2zyedJM2dK51xRmDqBgBAPUUPPQAA8K1XL6lBtO/zPvrI9srPmWN75W++2fbKk8wDAFDn6KEHAF9cLik1tewYEcPlcik1MdV7jGrExsp1ag+lfrFbatlKLld8xfdzcuyQ+pdftn8+8UTbKz9oUNCrCgBAfUFCDwC+xMVJu3eHuhYIgLjoOO2eujvU1XCMuDN6afcXHaWLp0hxT5W9sXy5dNVV0p499kuvm26SHn7Yth0AABAwDLkHAAD+8cyjX7/ePh8+LF13nTRypE3mO3WSVq2SnnqKZB4AgCAgoQcAAP7xJPTp6dLSpVKPHtLs2fa1G2+Utm6VzjordPUDAKCeYcg9APhy9GhZkrJmjRQbG9r6oM4cLTqqs+bZ2K6ZtEax0cS2OkdTOuqsBl9IhcVak3aWYpUvdexoF8AbMiTU1QMAoN4hoQcAX0pLpc8/LztGxCg1pfp87+feY1Sv1Lj0eXEveyy3NHmyNGOG1LhxiGsGAED9REIPAABq7oMlUtqQUNcCAIB6jTn0AACg5hhiDwBAyJHQAwAAAADgQCT0AAAAAAA4EAk9AAAAAAAOxKJ4AOCPli1DXQMESMs4YlsTNAUAAMIHCT0A+BIfLx04EOpaIADiY+J14HZi6y+aAgAA4YUh9wAAAAAAOBAJPQAAAAAADkRCDwC+HD1q99weMsQeI2IcLTqqIfOGaMi8ITpaRGx9oSkAABBemEMPAL6UlkqrV5cdI2KUmlKt/n619xjVoykAABBe6KEHAAAAAMCBSOgBAAAAAHAgEnoAAAAAAByIhB4AAAAAAAcioQcAAAAAwIFY5R4A/BEXF+oaIEDiooltTdAUAAAIHyT0AOBLfLyUmxvqWiAA4mPilXsPsfUXTQEAgPDCkHsAAAAAAByIhB4AAAAAAAcioQcAX/LzpbQ0+8jPD3VtUIfyi/OVtiBNaQvSlF9MbH2hKQAAEF6YQw8AvpSUSEuXlh0jYpSUlmjprqXeY1SPpgAAQHihhx4AAAAAAAcioQcAAAAAwIFI6AEAAAAAcCASegAAAAAAHIiEHgAAAAAAB2KVex+MMZKknJycENcEQMjk5pYd5+SwvHcEyS3MlX7dfi0nJ0clMcS2OjQFAACCw5N/evLRqriMrzPquR9//FHt2rULdTUAAAAAAPXMnj17dMIJJ1T5Pgm9D6Wlpdq7d6+aNGkil8vl8/w+ffpo06ZNAalLTk6O2rVrpz179ighISEg15ACew/BKD/Q1whGHJz+GQWj/EBc49jYOvEegl1+IK5BHMKvfH+v8Vv+fQyXewjn8v29BnGI3Huoq/+DRPJnFIxrEIfglR+Iazjl/xnGGB0+fFht2rSR2131THmG3Pvgdrur/UbkWFFRUQFNtiUpISEhoNcI9D0E4zNyehwi4TNy8j14YuvkewhW+YG8BnEIn/Jreo3a/PsYbvcQjuXX9BrEIXBCfQ+/9f8g9eEzCsY1iIOz78EJ/89ITEz0eQ6L4tWxyZMnh7oKv1mg7yEYn5HT4xAJnxH3EB7X4B7C4xpOLz8Y1+AewuMa3EN4XMPp5QfjGtxDeFyDewj9NRhy7yA5OTlKTExUdnZ2wL9FQtWIQ+QituGBODgXsQsPxCFyEdvwQBycLdLiFzV9+vTpoa4E/BcVFaUhQ4aoQQNmS4QScYhcxDY8EAfnInbhgThELmIbHoiDs0VS/OihBwAAAADAgZhDDwAAAACAA5HQAwAAAADgQCT0AAAAAAA4EAk9AAAAAAAOREJfiUceeUR9+vRRkyZNlJSUpAkTJmjnzp0VzsnPz9fkyZPVokULNW7cWOeff77279/vff/LL7/URRddpHbt2ik2NlannHKKnn766QplvPPOOxoxYoRatWqlhIQEDRgwQB999JHP+hljdP/996t169aKjY3V8OHDtWvXrgrnfPPNNxo/frxatmyphIQEDRo0SB9//LHPsrdu3aozzzxTjRo1Urt27TRz5swK72dkZOj8889Xhw4d5HK59NRTT/kss7bqaxzy8/M1adIk9ejRQw0aNNCECROOO2fVqlVyuVzHPfbt2+ez3uEgEmL7xRdfaMSIEWratKlatGiha665RkeOHPFZNm0s9HGIhDYW7rF75513NHLkSLVo0UIul0tbtmw57hxf9asKbSj0cYiENuRLJMT273//u4YMGaKEhAS5XC5lZWX5de8//PCD0tLSFBcXp6SkJN1+++0qLi72vp+ZmamJEyeqc+fOcrvdmjp1ql/l1kZ9jsNNN92k3r17q2HDhjrttNOOe3/37t2VtrH169f7VX4wOD1+//nPf3TjjTeqS5cuio2NVfv27XXTTTcpOzvbZ9nB/F1FQl+J1atXa/LkyVq/fr2WL1+uoqIijRw5Urm5ud5zbr75Zv3f//2fFi9erNWrV2vv3r36wx/+4H1/8+bNSkpK0j/+8Q9lZGTor3/9q+6++24999xz3nPWrFmjESNGaOnSpdq8ebOGDh2qcePGKT09vdr6zZw5U88884xefPFFbdiwQfHx8Ro1apTy8/O954wdO1bFxcVauXKlNm/erJ49e2rs2LHV/iLNycnRyJEjlZqaqs2bN2vWrFmaPn26/v73v3vPycvLU6dOnTRjxgylpKTU6HOtqfoah5KSEsXGxuqmm27S8OHDq63Dzp07lZmZ6X0kJSVVe364cHps9+7dq+HDh+vEE0/Uhg0btGzZMmVkZGjSpEnVlksbC484REIbC/fY5ebmatCgQXr00UerPMdX/SpDGwqPOERCG/IlEmKbl5en0aNH65577vH7vktKSpSWlqbCwkJ99tlnmj9/vubNm6f777/fe05BQYFatWqle++9Vz179vS77Nqor3HwuPLKK3XhhRdWe86KFSsqtLHevXvX+DqB4vT47d27V3v37tVjjz2m7du3a968eVq2bJmuuuqqassN+u8qA59+/vlnI8msXr3aGGNMVlaWiY6ONosXL/aes2PHDiPJrFu3rspybrjhBjN06NBqr9W1a1fzwAMPVPl+aWmpSUlJMbNmzfK+lpWVZRo2bGjeeOMNY4wxBw4cMJLMmjVrvOfk5OQYSWb58uVVlv3CCy+YZs2amYKCAu9rd955p+nSpUul56empponn3yy2vupS/UlDuVdfvnlZvz48ce9/vHHHxtJ5tChQ36VE+6cFtvZs2ebpKQkU1JS4j1n69atRpLZtWtXlWXTxsqEMg7lRUobC6fYlffdd98ZSSY9Pb3C67WtH22oTCjjUF6ktCFfnBbb8moSi6VLlxq322327dvnfe1//ud/TEJCQoV25zF48GAzZcoUv+paF+pLHMqbNm2a6dmzZ62uGW6cHD+PRYsWmZiYGFNUVFTlOcH+XUUPvR88wyqaN28uyX5TVFRUVOFb6ZNPPlnt27fXunXrqi3HU0ZlSktLdfjw4WrP+e6777Rv374K105MTFS/fv28127RooW6dOmiV199Vbm5uSouLtbs2bOVlJRU7bd269at01lnnaWYmBjva6NGjdLOnTt16NChKn8uWOpLHGritNNOU+vWrTVixAitXbu2TsoMBafFtqCgQDExMXK7y/4JjY2NlSR9+umnVZZNG7NCHYeacEobC6fY+aO29aMNWaGOQ004pQ354rTY1ta6devUo0cPJScne18bNWqUcnJylJGREZI6lVdf4lAT5557rpKSkjRo0CC9//77oa5OtSIhftnZ2UpISFCDBg2qPCfYv6tI6H0oLS3V1KlTdcYZZ6h79+6SpH379ikmJkZNmzatcG5ycnKVQ6k/++wzvfnmm7rmmmuqvNZjjz2mI0eO6E9/+lOV53jKL/8P7bHXdrlcWrFihdLT09WkSRM1atRITzzxhJYtW6ZmzZpVW3Zl5Za/bqjUpzj4o3Xr1nrxxRf19ttv6+2331a7du00ZMgQffHFF7+p3FBwYmzPPvts7du3T7NmzVJhYaEOHTqku+66S5KdW1hd2bSx0MfBH05qY+EWO3/Upn6en6MNhT4O/nBSG/LFibGtLdqYFeo4+KNx48Z6/PHHtXjxYi1ZskSDBg3ShAkTwjapj4T4/fLLL3rwwQervbYU/HZEQu/D5MmTtX37di1cuLDWZWzfvl3jx4/XtGnTNHLkyErPWbBggR544AEtWrTIO7/s9ddfV+PGjb2PTz75xK/rGWM0efJkJSUl6ZNPPtHGjRs1YcIEjRs3zvuf3G7dunnLHTNmTK3vLViIQ0VdunTRtddeq969e2vgwIGaM2eOBg4cqCeffNLvMsKFE2PbrVs3zZ8/X48//rji4uKUkpKijh07Kjk52dtbTBtzdhyc1MacGDt/0IacHQcntSFfIjW2Y8aM8ZbbrVu3Ois3UIhDRS1bttQtt9yifv36qU+fPpoxY4YuueQSzZo1q87qVpecHr+cnBylpaWpa9eumj59uvf1cPhdVfVYAegvf/mLPvjgA61Zs0YnnHCC9/WUlBQVFhYqKyurwjdK+/fvP25Rg6+++krDhg3TNddco3vvvbfS6yxcuFBXX321Fi9eXGHIybnnnqt+/fp5/9y2bVtvIrh//361bt26wrU9K2CuXLlSH3zwgQ4dOqSEhARJ0gsvvKDly5dr/vz5uuuuu7R06VIVFRVJKhuimpKSctzKtp4/B3phoerUtzjUVt++fetsmHGwODW2kjRx4kRNnDhR+/fvV3x8vFwul5544gl16tRJkmhjlQiXONRWOLaxcIydP/ypH23oeOESh9oKxzbki1Nj64+XX35ZR48elSRFR0d772vjxo0VzqONBT8OtdWvXz8tX768LqpVp5wev8OHD2v06NFq0qSJ/vd//7dCnMLid1WtZ99HsNLSUjN58mTTpk0b88033xz3vmcBh7feesv72tdff33cAg7bt283SUlJ5vbbb6/yWgsWLDCNGjUy7777rt91S0lJMY899pj3tezs7AoLRb3//vvG7Xabw4cPV/jZzp07m4ceeqjKsj0LOBQWFnpfu/vuu0O22FB9jUN5VS02VJnhw4eb8847z69zQ83psa3MK6+8YuLi4qpd7IY2Fh5xKM+pbSycY1eer8XYfNXvWLSh8IhDeU5tQ744Pbbl1WZRvP3793tfmz17tklISDD5+fnHnR/oRfHqaxzKq2pRvMpcffXVplevXjUqP5AiIX7Z2dmmf//+ZvDgwSY3N9ev8oL9u4qEvhLXX3+9SUxMNKtWrTKZmZneR15envec6667zrRv396sXLnSfP7552bAgAFmwIAB3ve3bdtmWrVqZS655JIKZfz888/ec15//XXToEED8/zzz1c4Jysrq9r6zZgxwzRt2tS89957ZuvWrWb8+PGmY8eO5ujRo8YYu7p6ixYtzB/+8AezZcsWs3PnTnPbbbeZ6Ohos2XLlirLzcrKMsnJyebSSy8127dvNwsXLjRxcXFm9uzZ3nMKCgpMenq6SU9PN61btza33XabSU9P93tF6Zqor3EwxpiMjAyTnp5uxo0bZ4YMGeL9zD2efPJJ8+6775pdu3aZbdu2mSlTphi3221WrFhRo884VJweW2OMefbZZ83mzZvNzp07zXPPPWdiY2PN008/XW25tLHwiIMxzm9j4R67gwcPmvT0dLNkyRIjySxcuNCkp6ebzMxMv+tXGdpQeMTBGOe3IV8iIbaZmZkmPT3dvPTSS95dd9LT083BgwerLLe4uNh0797djBw50mzZssUsW7bMtGrVytx9990VzvPEu3fv3mbixIkmPT3dZGRk+P35+qu+xsEYY3bt2mXS09PNtddeazp37uz9zD0rp8+bN88sWLDA7Nixw+zYscM89NBDxu12mzlz5tToMw4kp8cvOzvb9OvXz/To0cN8++23FcouLi6ustxg/64ioa+EpEofc+fO9Z5z9OhRc8MNN5hmzZqZuLg4c95551VovNOmTau0jNTUVO85gwcPrvScyy+/vNr6lZaWmvvuu88kJyebhg0bmmHDhpmdO3dWOGfTpk1m5MiRpnnz5qZJkyamf//+ZunSpT7v/csvvzSDBg0yDRs2NG3btjUzZsyo8L7nG6xjH4MHD/ZZdk3V5zikpqZWWiePRx991Pzud78zjRo1Ms2bNzdDhgwxK1eu9FluuIiE2F566aWmefPmJiYmxpx66qnm1Vdf9eveaWPhEQent7Fwj93cuXMr/blp06b5Xb+q0IbCIw5Ob0O+REJsq7p++XuozO7du82YMWNMbGysadmypbn11luP26LL133Vlfoch6rq9N133xljbEJ/yimnmLi4OJOQkGD69u1bYfu3cOD0+HlGVVQXh6oE83eVyxhjBAAAAAAAHIVV7gEAAAAAcCASegAAAAAAHIiEHgAAAAAAByKhBwAAAADAgUjoAQAAAABwIBJ6AAAAAAAciIQeAAAAAAAHIqEHAAAAAMCBSOgBAAAAAHAgEnoAAFCtSZMmyeVyyeVyKTo6WsnJyRoxYoTmzJmj0tJSv8uZN2+emjZtGsCaAgBQv5DQAwAAn0aPHq3MzEzt3r1bH374oYYOHaopU6Zo7NixKi4uDnX1AACol0joAQCATw0bNlRKSoratm2r3//+97rnnnv03nvv6cMPP9S8efMkSU888YR69Oih+Ph4tWvXTjfccIOOHDkiSVq1apWuuOIKZWdne3v7p0+fLkkqKCjQbbfdprZt2yo+Pl79+vXTqlWrQnOjAAA4CAk9AAColbPPPls9e/bUO++8I0lyu9165plnlJGRofnz52vlypW64447JEkDBw7UU089pYSEBGVmZiozM1O33XabJOkvf/mL1q1bp4ULF2rr1q264IILNHr0aO3atStk9wYAgBO4jDEm1JUAAADha9KkScrKytK777573Ht//vOftXXrVn311VfHvffWW2/puuuu0y+//CLJzqGfOnWqsrKyvOf88MMP6tSpk3744Qe1adPG+/rw4cPVt29fPfzwwwG4IwAAIkODUFcAAAA4lzFGLpdLkrRixQo98sgj+vrrr5WTk6Pi4mLl5+crLy9PcXFxlf78tm3bVFJSos6dO1d4vaCgQC1atAh4/QEAcDISegAAUGs7duxQx44dtXv3bo0dO1bXX3+9HnroITVv3lyffvqprrrqKhUWFlaZ0B85ckRRUVHavHmzoqKiKrzXuHHjYNwCAACORUIPAABqZeXKldq2bZtuvvlmbd68WaWlpXr88cfldtslehYtWlTh/JiYGJWUlFR4rVevXiopKdHPP/+sM888M2h1BwAgEpDQAwAAnwoKCrRv3z6VlJRo//79WrZsmR555BGNHTtWl112mbZv366ioiI9++yzGjdunNauXasXX3yxQhkdOnTQkSNH9K9//Us9e/ZUXFycOnfurIsvvliXXXaZHn/8cfXq1UsHDhzQv/71L5166qlKS0sL0R0DABD+WOUeAAD4tGzZMrVu3VodOnTQ6NGj9fHHH+uZZ57Re++9p6ioKPXs2VNPPPGEHn30UXXv3l2vv/66HnnkkQplDBw4UNddd50uvPBCtWrVSjNnzpQkzZ07V5dddpluvfVWdenSRRMmTNCmTZvUvn37UNwqAACOwSr3AAAAAAA4ED30AAAAAAA4EAk9AAAAAAAOREIPAAAAAIADkdADAAAAAOBAJPQAAAAAADgQCT0AAAAAAA5EQg8AAAAAgAOR0AMAAAAA4EAk9AAAAAAAOBAJPQAAAAAADkRCDwAAAACAA/1/2hm4R2FW9h0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x800 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "import matplotlib.ticker as ticker\n",
+    "\n",
+    "plt.style.use('default')\n",
+    "\n",
+    "\n",
+    "def formula_for_stock_return(symbol):\n",
+    "    return f\"round(({symbol}_open - LAG({symbol}_open, 1) OVER (ORDER BY date)) / LAG({symbol}_open, 1) OVER (ORDER BY date), 4) AS {symbol}_daily_return\"\n",
+    "\n",
+    "stocks = [\"SPY\"] + symbols\n",
+    "returns_df = spark.sql(f\"\"\"\n",
+    "SELECT date,  \n",
+    "       {\",\".join([formula_for_stock_return(stock) for stock in stocks])},\n",
+    "       {\",\".join(f\"{stock}_open,{stock}_close\" for stock in stocks)}\n",
+    "FROM glue_catalog.quant.historical_prices\n",
+    "ORDER BY date\n",
+    "\"\"\").toPandas()\n",
+    "returns_df['date'] = pd.to_datetime(returns_df['date'])\n",
+    "returns_df.set_index(\"date\", inplace=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12,8))\n",
+    "stocks_added={\"CSGP\", \"INVH\"}\n",
+    "\n",
+    "for col in stocks:\n",
+    "    c = f\"{col}_daily_return\"\n",
+    "    cum_returns = (1 + returns_df[c]).cumprod() - 1\n",
+    "    color = \"green\" if col in stocks_added else \"blue\" if col is \"SPY\" else \"red\"\n",
+    "    ax.plot(returns_df.index, cum_returns, label=col, color=color)\n",
+    "\n",
+    "\n",
+    "ax.set_title(\"Cumulative Returns Comparison\")\n",
+    "ax.set_xlabel(\"Date\")\n",
+    "ax.set_ylabel(\"Cumulative Return\")\n",
+    "ax.xaxis.set_major_locator(mdates.AutoDateLocator())\n",
+    "ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))\n",
+    "ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())\n",
+    "ax.axvline(pd.Timestamp('2022-09-02'), color='r', linestyle='--')\n",
+    "ax.axvline(pd.Timestamp('2022-09-19'), color='g', linestyle='--')\n",
+    "ax.axvline(pd.Timestamp('2022-09-30'), color='b', linestyle='--')\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "3d35c4e9-8e0f-488d-a143-046abca33b39",
+   "metadata": {},
+   "source": [
+    "As we can see in the graph actual divergence starts at the beginning of the September. However in the data we have date column as end of September. Then quant realizes here that data might be broken somehow. Luckily with Apache Iceberg we can go back in time and query the table based on tags. That will allow quants to see what was the state of the table at given point of time."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "1f43a0f5-f6b6-4b2e-9ba0-e52616f85bb6",
+   "metadata": {},
+   "source": [
+    "Let's backtest the following strategy for different position openning times. Here we'll long stocks added to the index and shorts equivalent amount of stocks removed from the index. We test short-term holding periods, such as 1 day and 1/2/3/4 weeks, as we assume that rebalancing effect is very short lived and new information, such as macro-economics, will drive performance beyond studied time horizons. Lastly we simulate different entry points for this trade \n",
+    "- market open the day after announcement day (AD+1) \n",
+    "- market close of effective date (ED0) \n",
+    "- market open the day after ETF holdings registered the change (MD+1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "0792a6e4-70dc-4933-8385-fe9bf0f90383",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:21:45.091689Z",
+     "iopub.status.busy": "2023-04-05T14:21:45.091286Z",
+     "iopub.status.idle": "2023-04-05T14:21:45.099760Z",
+     "shell.execute_reply": "2023-04-05T14:21:45.099124Z",
+     "shell.execute_reply.started": "2023-04-05T14:21:45.091660Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import vectorbt as vbt\n",
+    "\n",
+    "def backtest(entry_point='2022-09-02', exit_point='2022-10-31'):\n",
+    "    open_position = (historical_prices_pd.index == entry_point)\n",
+    "    close_position = (historical_prices_pd.index == exit_point)\n",
+    "\n",
+    "    CASH = 100000\n",
+    "    COMMPERC = 0.000\n",
+    "\n",
+    "    symbol_cols = pd.Index(['PENN', 'PVH', 'INVH', 'CSGP'], name='symbol')\n",
+    "    order_size = pd.DataFrame(index=historical_prices_pd.index, columns=symbol_cols)\n",
+    "    order_size['PENN'] = np.nan\n",
+    "    order_size['PVH'] = np.nan\n",
+    "    order_size['INVH'] = np.nan\n",
+    "    order_size['CSGP'] = np.nan\n",
+    "\n",
+    "    #short\n",
+    "    order_size.loc[open_position, 'PENN'] = -10\n",
+    "    order_size.loc[close_position, 'PENN'] = 0\n",
+    "\n",
+    "    order_size.loc[open_position, 'PVH'] = -10\n",
+    "    order_size.loc[close_position, 'PVH'] = 0\n",
+    "\n",
+    "    #long\n",
+    "    order_size.loc[open_position, 'INVH'] = 10\n",
+    "    order_size.loc[close_position, 'INVH'] = 0\n",
+    "\n",
+    "    order_size.loc[open_position, 'CSGP'] = 10\n",
+    "    order_size.loc[close_position, 'CSGP'] = 0\n",
+    "\n",
+    "    # Execute at the next bar\n",
+    "    order_size = order_size.vbt.fshift(1)\n",
+    "\n",
+    "    portfolio = vbt.Portfolio.from_orders(\n",
+    "            historical_close_prices,  # current close as reference price\n",
+    "            size=order_size,  \n",
+    "            price=historical_open_prices,  # current open as execution price\n",
+    "            size_type='targetpercent', \n",
+    "            val_price=historical_close_prices.vbt.fshift(1),  # previous close as group valuation price\n",
+    "            init_cash=CASH,\n",
+    "            allow_partial=False,\n",
+    "            fees=COMMPERC,\n",
+    "            direction='both',\n",
+    "            cash_sharing=True,  # share capital between assets in the same group\n",
+    "            group_by=True,  # all columns belong to the same group\n",
+    "            call_seq='auto',  # sell before buying\n",
+    "            freq='d'  # index frequency for annualization\n",
+    "    )\n",
+    "    return portfolio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "289f4533-767f-49ea-8646-e590414dfa5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:22:42.269950Z",
+     "iopub.status.busy": "2023-04-05T14:22:42.269545Z",
+     "iopub.status.idle": "2023-04-05T14:22:42.288865Z",
+     "shell.execute_reply": "2023-04-05T14:22:42.288155Z",
+     "shell.execute_reply.started": "2023-04-05T14:22:42.269921Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "portfolio = backtest('2022-09-02', '2022-10-31')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "68cb1ad0-d60b-4ebc-83d7-83b606abd1d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:22:43.841204Z",
+     "iopub.status.busy": "2023-04-05T14:22:43.840784Z",
+     "iopub.status.idle": "2023-04-05T14:22:43.863018Z",
+     "shell.execute_reply": "2023-04-05T14:22:43.862309Z",
+     "shell.execute_reply.started": "2023-04-05T14:22:43.841176Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Order Id</th>\n",
+       "      <th>Column</th>\n",
+       "      <th>Timestamp</th>\n",
+       "      <th>Size</th>\n",
+       "      <th>Price</th>\n",
+       "      <th>Fees</th>\n",
+       "      <th>Side</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>(PENN, PENN)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>31948.881789</td>\n",
+       "      <td>31.66</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>(PVH, PVH)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>18321.729571</td>\n",
+       "      <td>55.15</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>(INVH, INVH)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>27419.797094</td>\n",
+       "      <td>38.20</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>(CSGP, CSGP)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>14106.361969</td>\n",
+       "      <td>75.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>(CSGP, CSGP)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>14106.361969</td>\n",
+       "      <td>83.70</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5</td>\n",
+       "      <td>(INVH, INVH)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>27419.797094</td>\n",
+       "      <td>31.94</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6</td>\n",
+       "      <td>(PVH, PVH)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>18321.729571</td>\n",
+       "      <td>52.95</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>7</td>\n",
+       "      <td>(PENN, PENN)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>31948.881789</td>\n",
+       "      <td>34.09</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Order Id        Column  Timestamp          Size  Price  Fees  Side\n",
+       "0         0  (PENN, PENN) 2022-09-06  31948.881789  31.66   0.0  Sell\n",
+       "1         1    (PVH, PVH) 2022-09-06  18321.729571  55.15   0.0  Sell\n",
+       "2         2  (INVH, INVH) 2022-09-06  27419.797094  38.20   0.0   Buy\n",
+       "3         3  (CSGP, CSGP) 2022-09-06  14106.361969  75.00   0.0   Buy\n",
+       "4         4  (CSGP, CSGP) 2022-11-01  14106.361969  83.70   0.0  Sell\n",
+       "5         5  (INVH, INVH) 2022-11-01  27419.797094  31.94   0.0  Sell\n",
+       "6         6    (PVH, PVH) 2022-11-01  18321.729571  52.95   0.0   Buy\n",
+       "7         7  (PENN, PENN) 2022-11-01  31948.881789  34.09   0.0   Buy"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portfolio.orders.records_readable.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "c94d972d-de9f-402f-a5ac-56d61c6b6acb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:22:52.640161Z",
+     "iopub.status.busy": "2023-04-05T14:22:52.639754Z",
+     "iopub.status.idle": "2023-04-05T14:22:52.658286Z",
+     "shell.execute_reply": "2023-04-05T14:22:52.657619Z",
+     "shell.execute_reply.started": "2023-04-05T14:22:52.640131Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "date\n",
+       "2022-08-01    100000.000000\n",
+       "2022-08-02    100000.000000\n",
+       "2022-08-03    100000.000000\n",
+       "2022-08-04    100000.000000\n",
+       "2022-08-05    100000.000000\n",
+       "                  ...      \n",
+       "2022-11-25     13749.441636\n",
+       "2022-11-28     13749.441636\n",
+       "2022-11-29     13749.441636\n",
+       "2022-11-30     13749.441636\n",
+       "2022-12-01     13749.441636\n",
+       "Name: cash, Length: 87, dtype: float64"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portfolio.cash().rename('cash')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "e7ea9904-171c-4661-b0b2-450675733ecb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:23:08.233532Z",
+     "iopub.status.busy": "2023-04-05T14:23:08.233129Z",
+     "iopub.status.idle": "2023-04-05T14:23:08.252699Z",
+     "shell.execute_reply": "2023-04-05T14:23:08.251950Z",
+     "shell.execute_reply.started": "2023-04-05T14:23:08.233504Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "portfolio2 = backtest('2022-09-19', '2022-10-31')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "eac2250b-1f10-48c9-b671-32c4a8be2629",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:22:54.502412Z",
+     "iopub.status.busy": "2023-04-05T14:22:54.502007Z",
+     "iopub.status.idle": "2023-04-05T14:22:54.524180Z",
+     "shell.execute_reply": "2023-04-05T14:22:54.523511Z",
+     "shell.execute_reply.started": "2023-04-05T14:22:54.502384Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Order Id</th>\n",
+       "      <th>Column</th>\n",
+       "      <th>Timestamp</th>\n",
+       "      <th>Size</th>\n",
+       "      <th>Price</th>\n",
+       "      <th>Fees</th>\n",
+       "      <th>Side</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>(PENN, PENN)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>31948.881789</td>\n",
+       "      <td>31.66</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>(PVH, PVH)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>18321.729571</td>\n",
+       "      <td>55.15</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>(INVH, INVH)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>27419.797094</td>\n",
+       "      <td>38.20</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>(CSGP, CSGP)</td>\n",
+       "      <td>2022-09-06</td>\n",
+       "      <td>14106.361969</td>\n",
+       "      <td>75.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>(CSGP, CSGP)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>14106.361969</td>\n",
+       "      <td>83.70</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5</td>\n",
+       "      <td>(INVH, INVH)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>27419.797094</td>\n",
+       "      <td>31.94</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Sell</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6</td>\n",
+       "      <td>(PVH, PVH)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>18321.729571</td>\n",
+       "      <td>52.95</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>7</td>\n",
+       "      <td>(PENN, PENN)</td>\n",
+       "      <td>2022-11-01</td>\n",
+       "      <td>31948.881789</td>\n",
+       "      <td>34.09</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Buy</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Order Id        Column  Timestamp          Size  Price  Fees  Side\n",
+       "0         0  (PENN, PENN) 2022-09-06  31948.881789  31.66   0.0  Sell\n",
+       "1         1    (PVH, PVH) 2022-09-06  18321.729571  55.15   0.0  Sell\n",
+       "2         2  (INVH, INVH) 2022-09-06  27419.797094  38.20   0.0   Buy\n",
+       "3         3  (CSGP, CSGP) 2022-09-06  14106.361969  75.00   0.0   Buy\n",
+       "4         4  (CSGP, CSGP) 2022-11-01  14106.361969  83.70   0.0  Sell\n",
+       "5         5  (INVH, INVH) 2022-11-01  27419.797094  31.94   0.0  Sell\n",
+       "6         6    (PVH, PVH) 2022-11-01  18321.729571  52.95   0.0   Buy\n",
+       "7         7  (PENN, PENN) 2022-11-01  31948.881789  34.09   0.0   Buy"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portfolio.orders.records_readable.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "70ef5464-3252-4d31-81e6-2e0530d106ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-05T14:22:36.675100Z",
+     "iopub.status.busy": "2023-04-05T14:22:36.674689Z",
+     "iopub.status.idle": "2023-04-05T14:22:36.693460Z",
+     "shell.execute_reply": "2023-04-05T14:22:36.692767Z",
+     "shell.execute_reply.started": "2023-04-05T14:22:36.675070Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "date\n",
+       "2022-08-01    100000.000000\n",
+       "2022-08-02    100000.000000\n",
+       "2022-08-03    100000.000000\n",
+       "2022-08-04    100000.000000\n",
+       "2022-08-05    100000.000000\n",
+       "                  ...      \n",
+       "2022-11-25     13749.441636\n",
+       "2022-11-28     13749.441636\n",
+       "2022-11-29     13749.441636\n",
+       "2022-11-30     13749.441636\n",
+       "2022-12-01     13749.441636\n",
+       "Name: cash, Length: 87, dtype: float64"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portfolio.cash().rename('cash')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10c1f7d3-501c-461f-98c5-864f348aeeee",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "PySpark (Kubernetes)",
+   "language": "python",
+   "name": "spark_python_kubernetes"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Issue #1 :*

*Description of changes:*
- Iceberg uses Glue data catalog. And its data catalog implementation uses DynamoDB therefore added policy for Glue and DynamoDB to managed-endpoint IAM role so that iceberg can create tables in the Glue data catalog
- removed conflicting dependencies as they're already coming from upstream reference architecture dependency
- Baked Iceberg 1.3.0 into the docker image so that we can configure credential provider. In this case we use `WebIdentityTokenFileCredentialsProvider` otherwise Iceberg picks up `KarpenterNodeRole-adx<REGION>-cluster` instead of `managed-endpoint-1-<REGION>-execRole`. As `KarpenterNodeRole` is inherited from upstream dependency we don't have much control over it therefore using correct credential provider is important so that we can use managed-endpoint role.
- Add `aws-crt` dependency to docker image to make MRAP work because S3 Multi-Region Access Point (MRAP) relies on signer class from `aws-crt` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
