### PR TITLE
Use querying via tag instead of querying via status field

### DIFF
--- a/src/notebooks/etf holdings/notebook.ipynb
+++ b/src/notebooks/etf holdings/notebook.ipynb
@@ -430,7 +430,7 @@
    "id": "ecba91d6-f935-4186-8c57-ee4aaa7da4e1",
    "metadata": {},
    "source": [
-    "Let's query the expired and newly added stocks to see the effect of rebalance on the ETF"
+    "Let's query the newly added and expired stocks to see the effect of rebalance on the ETF"
    ]
   },
   {
@@ -472,7 +472,10 @@
    "source": [
     "spark.sql(\"\"\"SELECT symbol, isin, acceptanceTime, date \n",
     "FROM glue_catalog.quant.etf_holdings \n",
-    "where status='new'\n",
+    "AS OF 'Q3_2022' EXCEPT \n",
+    "SELECT symbol, isin, acceptanceTime, date \n",
+    "FROM glue_catalog.quant.etf_holdings \n",
+    "AS OF 'Q1_2022'\n",
     "\"\"\").show()\n"
    ]
   },
@@ -525,7 +528,10 @@
    "source": [
     "spark.sql(\"\"\"SELECT symbol, isin, acceptanceTime, date \n",
     "FROM glue_catalog.quant.etf_holdings \n",
-    "where status='expired'\n",
+    "AS OF 'Q1_2022' EXCEPT \n",
+    "SELECT symbol, isin, acceptanceTime, date \n",
+    "FROM glue_catalog.quant.etf_holdings \n",
+    "AS OF 'Q3_2022'\n",
     "\"\"\").show()"
    ]
   },


### PR DESCRIPTION
The notebook should be updated to use time travel via tag when determining newly added and expired stocks